### PR TITLE
Enforces consistent quote style across codebase

### DIFF
--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,2 +1,2 @@
-export { Translatable, getTranslatableFields } from './translatable.decorator';
-export { IsTranslations } from './is-translations.decorator';
+export { Translatable, getTranslatableFields } from "./translatable.decorator";
+export { IsTranslations } from "./is-translations.decorator";

--- a/src/decorators/is-translations.decorator.ts
+++ b/src/decorators/is-translations.decorator.ts
@@ -1,17 +1,17 @@
-import { registerDecorator, ValidationOptions } from 'class-validator';
+import { registerDecorator, ValidationOptions } from "class-validator";
 import {
   IsTranslationsConstraint,
   IsTranslationsOptions,
-} from '../validators/is-translations.constraint';
+} from "../validators/is-translations.constraint";
 
 export function IsTranslations(
   options?: IsTranslationsOptions,
   validationOptions?: ValidationOptions,
 ): PropertyDecorator {
-  return function (object: object, propertyName: string) {
+  return function (object: object, propertyName: string | symbol) {
     registerDecorator({
       target: object.constructor,
-      propertyName,
+      propertyName: String(propertyName),
       options: {
         message:
           'Must be a valid translation map (e.g. { "en": "Hello", "fr": "Bonjour" })',

--- a/src/decorators/translatable.decorator.ts
+++ b/src/decorators/translatable.decorator.ts
@@ -1,5 +1,5 @@
-import 'reflect-metadata';
-import { TRANSLATABLE_METADATA_KEY } from '../translatable.constants';
+import "reflect-metadata";
+import { TRANSLATABLE_METADATA_KEY } from "../translatable.constants";
 
 export function Translatable(): PropertyDecorator {
   return (target: object, propertyKey: string | symbol) => {
@@ -17,6 +17,8 @@ export function Translatable(): PropertyDecorator {
   };
 }
 
-export function getTranslatableFields(target: Function): string[] {
+export function getTranslatableFields(
+  target: abstract new (...args: any[]) => any,
+): string[] {
   return Reflect.getMetadata(TRANSLATABLE_METADATA_KEY, target) || [];
 }

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,1 +1,1 @@
-export { TranslationHasBeenSetEvent } from './translation-has-been-set.event';
+export { TranslationHasBeenSetEvent } from "./translation-has-been-set.event";

--- a/src/exceptions/attribute-is-not-translatable.exception.ts
+++ b/src/exceptions/attribute-is-not-translatable.exception.ts
@@ -1,8 +1,8 @@
 export class AttributeIsNotTranslatableException extends Error {
   constructor(key: string, translatableAttributes: string[]) {
     super(
-      `Cannot translate attribute "${key}" as it's not one of the translatable attributes: ${translatableAttributes.join(', ')}`,
+      `Cannot translate attribute "${key}" as it's not one of the translatable attributes: ${translatableAttributes.join(", ")}`,
     );
-    this.name = 'AttributeIsNotTranslatableException';
+    this.name = "AttributeIsNotTranslatableException";
   }
 }

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,1 +1,1 @@
-export { AttributeIsNotTranslatableException } from './attribute-is-not-translatable.exception';
+export { AttributeIsNotTranslatableException } from "./attribute-is-not-translatable.exception";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,38 @@
 // Module
-export { TranslatableModule } from './translatable.module';
+export { TranslatableModule } from "./translatable.module";
 
 // Service
-export { TranslatableService } from './translatable.service';
+export { TranslatableService } from "./translatable.service";
 
 // Constants
 export {
   TRANSLATABLE_OPTIONS,
   TRANSLATABLE_METADATA_KEY,
-} from './translatable.constants';
+} from "./translatable.constants";
 
 // Decorators
-export { Translatable, getTranslatableFields } from './decorators';
-export { IsTranslations } from './decorators';
+export { Translatable, getTranslatableFields } from "./decorators";
+export { IsTranslations } from "./decorators";
 
 // Mixin
-export { TranslatableMixin } from './mixins';
-export type { TranslatableEntity } from './mixins';
+export { TranslatableMixin } from "./mixins";
+export type { TranslatableEntity } from "./mixins";
 
 // Subscriber
-export { TranslatableSubscriber } from './translatable.subscriber';
+export { TranslatableSubscriber } from "./translatable.subscriber";
 
 // Middleware & Interceptor
-export { TranslatableMiddleware, TranslatableInterceptor } from './middleware';
+export { TranslatableMiddleware, TranslatableInterceptor } from "./middleware";
 
 // Validators
-export { IsTranslationsConstraint } from './validators';
-export type { IsTranslationsOptions } from './validators';
+export { IsTranslationsConstraint } from "./validators";
+export type { IsTranslationsOptions } from "./validators";
 
 // Events
-export { TranslationHasBeenSetEvent } from './events';
+export { TranslationHasBeenSetEvent } from "./events";
 
 // Exceptions
-export { AttributeIsNotTranslatableException } from './exceptions';
+export { AttributeIsNotTranslatableException } from "./exceptions";
 
 // Query helpers
 export {
@@ -41,11 +41,11 @@ export {
   whereLocale,
   whereLocales,
   orderByTranslation,
-} from './query';
+} from "./query";
 
 // Interfaces
 export type {
   TranslatableModuleOptions,
   TranslatableAsyncOptions,
-} from './interfaces';
-export type { TranslationMap } from './interfaces';
+} from "./interfaces";
+export type { TranslationMap } from "./interfaces";

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,5 +1,5 @@
 export {
   TranslatableModuleOptions,
   TranslatableAsyncOptions,
-} from './translatable-options.interface';
-export { TranslationMap } from './translation-map.interface';
+} from "./translatable-options.interface";
+export { TranslationMap } from "./translation-map.interface";

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,2 +1,2 @@
-export { TranslatableMiddleware } from './translatable.middleware';
-export { TranslatableInterceptor } from './translatable.interceptor';
+export { TranslatableMiddleware } from "./translatable.middleware";
+export { TranslatableInterceptor } from "./translatable.interceptor";

--- a/src/middleware/translatable.interceptor.ts
+++ b/src/middleware/translatable.interceptor.ts
@@ -3,11 +3,11 @@ import {
   ExecutionContext,
   Injectable,
   NestInterceptor,
-} from '@nestjs/common';
-import { Observable, map } from 'rxjs';
-import { Request } from 'express';
-import { TRANSLATABLE_METADATA_KEY } from '../translatable.constants';
-import { TranslatableService } from '../translatable.service';
+} from "@nestjs/common";
+import { Observable, map } from "rxjs";
+import { Request } from "express";
+import { TRANSLATABLE_METADATA_KEY } from "../translatable.constants";
+import { TranslatableService } from "../translatable.service";
 
 @Injectable()
 export class TranslatableInterceptor implements NestInterceptor {
@@ -15,7 +15,7 @@ export class TranslatableInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest<Request>();
-    const hasLocaleHeader = !!request.headers['accept-language'];
+    const hasLocaleHeader = !!request.headers["accept-language"];
 
     return next.handle().pipe(
       map((data) => {
@@ -34,7 +34,7 @@ export class TranslatableInterceptor implements NestInterceptor {
       return data.map((item) => this.resolveTranslations(item, locale));
     }
 
-    if (typeof data !== 'object') return data;
+    if (typeof data !== "object") return data;
 
     // Check if data has translatable metadata (is a translatable entity)
     const fields = this.getTranslatableFields(data);
@@ -49,7 +49,7 @@ export class TranslatableInterceptor implements NestInterceptor {
         result[key] = value.map((item) =>
           this.resolveTranslations(item, locale),
         );
-      } else if (value != null && typeof value === 'object') {
+      } else if (value != null && typeof value === "object") {
         const nestedFields = this.getTranslatableFields(value);
         if (nestedFields.length > 0) {
           result[key] = this.resolveEntity(value, nestedFields, locale);
@@ -71,13 +71,13 @@ export class TranslatableInterceptor implements NestInterceptor {
     const result: Record<string, any> = {};
 
     for (const key of Object.keys(entity)) {
-      if (typeof entity[key] === 'function') continue;
+      if (typeof entity[key] === "function") continue;
 
       if (fields.includes(key)) {
         const translations = entity[key];
         if (
           translations != null &&
-          typeof translations === 'object' &&
+          typeof translations === "object" &&
           !Array.isArray(translations)
         ) {
           result[key] = this.resolveValue(translations, locale);
@@ -97,7 +97,7 @@ export class TranslatableInterceptor implements NestInterceptor {
     locale: string,
   ): string | null {
     const translatedLocales = Object.keys(translations).filter(
-      (l) => translations[l] != null && translations[l] !== '',
+      (l) => translations[l] != null && translations[l] !== "",
     );
 
     const resolved = this.translatableService.resolveLocale(
@@ -107,7 +107,7 @@ export class TranslatableInterceptor implements NestInterceptor {
     );
 
     const value = translations[resolved];
-    if (value == null || value === '') return null;
+    if (value == null || value === "") return null;
     return value;
   }
 

--- a/src/middleware/translatable.middleware.ts
+++ b/src/middleware/translatable.middleware.ts
@@ -1,13 +1,13 @@
-import { Injectable, NestMiddleware } from '@nestjs/common';
-import { Request, Response, NextFunction } from 'express';
-import { TranslatableService } from '../translatable.service';
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { Request, Response, NextFunction } from "express";
+import { TranslatableService } from "../translatable.service";
 
 @Injectable()
 export class TranslatableMiddleware implements NestMiddleware {
   constructor(private readonly translatableService: TranslatableService) {}
 
   use(req: Request, res: Response, next: NextFunction): void {
-    const header = req.headers['accept-language'];
+    const header = req.headers["accept-language"];
     const locale = this.parseLocale(header);
 
     if (locale) {
@@ -20,11 +20,11 @@ export class TranslatableMiddleware implements NestMiddleware {
   private parseLocale(header: string | undefined): string | null {
     if (!header) return null;
 
-    const first = header.split(',')[0]?.trim();
+    const first = header.split(",")[0]?.trim();
     if (!first) return null;
 
     // Strip quality value: "en-US;q=0.9" → "en-US"
-    const locale = first.split(';')[0]?.trim();
+    const locale = first.split(";")[0]?.trim();
     if (!locale) return null;
 
     return locale;

--- a/src/mixins/index.ts
+++ b/src/mixins/index.ts
@@ -1,2 +1,2 @@
-export { TranslatableMixin } from './translatable.mixin';
-export type { TranslatableEntity } from './translatable.mixin';
+export { TranslatableMixin } from "./translatable.mixin";
+export type { TranslatableEntity } from "./translatable.mixin";

--- a/src/mixins/translatable.mixin.ts
+++ b/src/mixins/translatable.mixin.ts
@@ -1,8 +1,8 @@
-import 'reflect-metadata';
-import { TRANSLATABLE_METADATA_KEY } from '../translatable.constants';
-import { TranslatableService } from '../translatable.service';
-import { AttributeIsNotTranslatableException } from '../exceptions';
-import { TranslationMap } from '../interfaces';
+import "reflect-metadata";
+import { TRANSLATABLE_METADATA_KEY } from "../translatable.constants";
+import { TranslatableService } from "../translatable.service";
+import { AttributeIsNotTranslatableException } from "../exceptions";
+import { TranslationMap } from "../interfaces";
 
 type Constructor<T = object> = new (...args: any[]) => T;
 
@@ -32,10 +32,7 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
   class TranslatableEntityClass extends Base implements TranslatableEntity {
     getTranslatableAttributes(): string[] {
       return (
-        Reflect.getMetadata(
-          TRANSLATABLE_METADATA_KEY,
-          this.constructor,
-        ) || []
+        Reflect.getMetadata(TRANSLATABLE_METADATA_KEY, this.constructor) || []
       );
     }
 
@@ -53,11 +50,10 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
       const translations = this.getTranslationMap(key);
       const service = TranslatableService.getInstance();
 
-      const requestedLocale =
-        locale ?? service?.getLocale() ?? 'en';
+      const requestedLocale = locale ?? service?.getLocale() ?? "en";
 
       const translatedLocales = Object.keys(translations).filter(
-        (l) => translations[l] != null && translations[l] !== '',
+        (l) => translations[l] != null && translations[l] !== "",
       );
 
       const resolvedLocale = service
@@ -65,11 +61,11 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
         : useFallback
           ? translatedLocales.includes(requestedLocale)
             ? requestedLocale
-            : translatedLocales[0] ?? requestedLocale
+            : (translatedLocales[0] ?? requestedLocale)
           : requestedLocale;
 
       const value = translations[resolvedLocale];
-      if (value == null || value === '') {
+      if (value == null || value === "") {
         return null;
       }
 
@@ -98,17 +94,13 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
       return result;
     }
 
-    setTranslation(
-      key: string,
-      locale: string,
-      value: string | null,
-    ): this {
+    setTranslation(key: string, locale: string, value: string | null): this {
       this.guardTranslatableAttribute(key);
 
       const translations = this.getTranslationMap(key);
       const oldValue = translations[locale] ?? null;
 
-      if (value == null || value === '') {
+      if (value == null || value === "") {
         delete translations[locale];
       } else {
         translations[locale] = value;
@@ -162,10 +154,10 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
 
       const translations = this.getTranslationMap(key);
       const checkLocale =
-        locale ?? TranslatableService.getInstance()?.getLocale() ?? 'en';
+        locale ?? TranslatableService.getInstance()?.getLocale() ?? "en";
 
       const value = translations[checkLocale];
-      return value != null && value !== '';
+      return value != null && value !== "";
     }
 
     getTranslatedLocales(key: string): string[] {
@@ -173,7 +165,7 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
 
       const translations = this.getTranslationMap(key);
       return Object.keys(translations).filter(
-        (l) => translations[l] != null && translations[l] !== '',
+        (l) => translations[l] != null && translations[l] !== "",
       );
     }
 
@@ -191,7 +183,7 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
     getTranslationMap(key: string): TranslationMap {
       const raw = (this as any)[key];
       if (raw == null) return {};
-      if (typeof raw === 'object' && !Array.isArray(raw)) return { ...raw };
+      if (typeof raw === "object" && !Array.isArray(raw)) return { ...raw };
       return {};
     }
 
@@ -212,7 +204,7 @@ export function TranslatableMixin<TBase extends Constructor>(Base: TBase) {
     ): TranslationMap {
       const result: TranslationMap = {};
       for (const [locale, value] of Object.entries(translations)) {
-        if (value == null || value === '') continue;
+        if (value == null || value === "") continue;
         if (allowedLocales && !allowedLocales.includes(locale)) continue;
         result[locale] = value;
       }

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -4,4 +4,4 @@ export {
   whereLocale,
   whereLocales,
   orderByTranslation,
-} from './translatable-query.helpers';
+} from "./translatable-query.helpers";

--- a/src/query/translatable-query.helpers.ts
+++ b/src/query/translatable-query.helpers.ts
@@ -1,4 +1,4 @@
-import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
 
 export function whereTranslation<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
@@ -8,7 +8,7 @@ export function whereTranslation<T extends ObjectLiteral>(
   alias?: string,
 ): SelectQueryBuilder<T> {
   const tableAlias = alias ?? qb.alias;
-  const paramKey = `${column}_${locale}_val`.replace(/[^a-zA-Z0-9_]/g, '_');
+  const paramKey = `${column}_${locale}_val`.replace(/[^a-zA-Z0-9_]/g, "_");
   return qb.andWhere(
     `"${tableAlias}"."${column}"->>'${locale}' = :${paramKey}`,
     { [paramKey]: value },
@@ -23,7 +23,7 @@ export function whereTranslationLike<T extends ObjectLiteral>(
   alias?: string,
 ): SelectQueryBuilder<T> {
   const tableAlias = alias ?? qb.alias;
-  const paramKey = `${column}_${locale}_like`.replace(/[^a-zA-Z0-9_]/g, '_');
+  const paramKey = `${column}_${locale}_like`.replace(/[^a-zA-Z0-9_]/g, "_");
   return qb.andWhere(
     `"${tableAlias}"."${column}"->>'${locale}' ILIKE :${paramKey}`,
     { [paramKey]: pattern },
@@ -37,9 +37,7 @@ export function whereLocale<T extends ObjectLiteral>(
   alias?: string,
 ): SelectQueryBuilder<T> {
   const tableAlias = alias ?? qb.alias;
-  return qb.andWhere(
-    `"${tableAlias}"."${column}"->>'${locale}' IS NOT NULL`,
-  );
+  return qb.andWhere(`"${tableAlias}"."${column}"->>'${locale}' IS NOT NULL`);
 }
 
 export function whereLocales<T extends ObjectLiteral>(
@@ -51,7 +49,7 @@ export function whereLocales<T extends ObjectLiteral>(
   const tableAlias = alias ?? qb.alias;
   const conditions = locales
     .map((l) => `"${tableAlias}"."${column}"->>'${l}' IS NOT NULL`)
-    .join(' OR ');
+    .join(" OR ");
   return qb.andWhere(`(${conditions})`);
 }
 
@@ -59,12 +57,9 @@ export function orderByTranslation<T extends ObjectLiteral>(
   qb: SelectQueryBuilder<T>,
   column: string,
   locale: string,
-  order: 'ASC' | 'DESC' = 'ASC',
+  order: "ASC" | "DESC" = "ASC",
   alias?: string,
 ): SelectQueryBuilder<T> {
   const tableAlias = alias ?? qb.alias;
-  return qb.addOrderBy(
-    `"${tableAlias}"."${column}"->>'${locale}'`,
-    order,
-  );
+  return qb.addOrderBy(`"${tableAlias}"."${column}"->>'${locale}'`, order);
 }

--- a/src/translatable.constants.ts
+++ b/src/translatable.constants.ts
@@ -1,2 +1,2 @@
-export const TRANSLATABLE_OPTIONS = 'TRANSLATABLE_OPTIONS';
-export const TRANSLATABLE_METADATA_KEY = 'translatable:fields';
+export const TRANSLATABLE_OPTIONS = "TRANSLATABLE_OPTIONS";
+export const TRANSLATABLE_METADATA_KEY = "translatable:fields";

--- a/src/translatable.module.ts
+++ b/src/translatable.module.ts
@@ -1,19 +1,17 @@
-import { DynamicModule, Module } from '@nestjs/common';
-import { TRANSLATABLE_OPTIONS } from './translatable.constants';
+import { DynamicModule, Module } from "@nestjs/common";
+import { TRANSLATABLE_OPTIONS } from "./translatable.constants";
 import {
   TranslatableModuleOptions,
   TranslatableAsyncOptions,
-} from './interfaces';
-import { TranslatableService } from './translatable.service';
-import { TranslatableSubscriber } from './translatable.subscriber';
-import { IsTranslationsConstraint } from './validators';
-import { TranslatableInterceptor } from './middleware';
+} from "./interfaces";
+import { TranslatableService } from "./translatable.service";
+import { TranslatableSubscriber } from "./translatable.subscriber";
+import { IsTranslationsConstraint } from "./validators";
+import { TranslatableInterceptor } from "./middleware";
 
 @Module({})
 export class TranslatableModule {
-  static forRoot(
-    options: TranslatableModuleOptions = {},
-  ): DynamicModule {
+  static forRoot(options: TranslatableModuleOptions = {}): DynamicModule {
     return {
       module: TranslatableModule,
       global: true,

--- a/src/translatable.service.ts
+++ b/src/translatable.service.ts
@@ -1,15 +1,14 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { Inject, Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
-import { TRANSLATABLE_OPTIONS } from './translatable.constants';
-import { TranslatableModuleOptions } from './interfaces';
-import { TranslationHasBeenSetEvent } from './events';
-
-let EventEmitter2: any;
-try {
-  EventEmitter2 = require('@nestjs/event-emitter').EventEmitter2;
-} catch /* v8 ignore next */ {
-  EventEmitter2 = null;
-}
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleInit,
+  Optional,
+} from "@nestjs/common";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { TranslationHasBeenSetEvent } from "./events";
+import { TranslatableModuleOptions } from "./interfaces";
+import { TRANSLATABLE_OPTIONS } from "./translatable.constants";
 
 @Injectable()
 export class TranslatableService implements OnModuleInit {
@@ -27,9 +26,9 @@ export class TranslatableService implements OnModuleInit {
   constructor(
     @Inject(TRANSLATABLE_OPTIONS)
     options: TranslatableModuleOptions,
-    @Optional() @Inject('EventEmitter2') eventEmitter?: any,
+    @Optional() @Inject("EventEmitter2") eventEmitter?: any,
   ) {
-    this.defaultLocale = options.defaultLocale ?? 'en';
+    this.defaultLocale = options.defaultLocale ?? "en";
     this.fallbackLocale = options.fallbackLocale ?? this.defaultLocale;
     this.fallbackAny = options.fallbackAny ?? false;
 
@@ -107,7 +106,7 @@ export class TranslatableService implements OnModuleInit {
     if (!this.eventEmitter) return;
 
     this.eventEmitter.emit(
-      'translatable.translation-set',
+      "translatable.translation-set",
       new TranslationHasBeenSetEvent(entity, key, locale, oldValue, newValue),
     );
   }

--- a/src/translatable.subscriber.ts
+++ b/src/translatable.subscriber.ts
@@ -1,16 +1,11 @@
-import 'reflect-metadata';
-import { Injectable } from '@nestjs/common';
-import {
-  EntitySubscriberInterface,
-  InsertEvent,
-  UpdateEvent,
-  LoadEvent,
-} from 'typeorm';
-import { TRANSLATABLE_METADATA_KEY } from './translatable.constants';
+import { Injectable } from "@nestjs/common";
+import "reflect-metadata";
+import { EntitySubscriberInterface, InsertEvent, UpdateEvent } from "typeorm";
+import { TRANSLATABLE_METADATA_KEY } from "./translatable.constants";
 
 @Injectable()
 export class TranslatableSubscriber implements EntitySubscriberInterface {
-  afterLoad(entity: any, event?: LoadEvent<any>): void {
+  afterLoad(entity: any): void {
     this.ensureTranslationMaps(entity);
   }
 
@@ -35,7 +30,7 @@ export class TranslatableSubscriber implements EntitySubscriberInterface {
     const fields = this.getTranslatableFields(entity);
     for (const field of fields) {
       const value = entity[field];
-      if (typeof value === 'string') {
+      if (typeof value === "string") {
         try {
           entity[field] = JSON.parse(value);
         } catch {
@@ -51,10 +46,10 @@ export class TranslatableSubscriber implements EntitySubscriberInterface {
     const fields = this.getTranslatableFields(entity);
     for (const field of fields) {
       const value = entity[field];
-      if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+      if (value != null && typeof value === "object" && !Array.isArray(value)) {
         const cleaned: Record<string, string> = {};
         for (const [locale, text] of Object.entries(value)) {
-          if (text != null && text !== '') {
+          if (text != null && text !== "") {
             cleaned[locale] = text as string;
           }
         }

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,4 +1,4 @@
 export {
   IsTranslationsConstraint,
   IsTranslationsOptions,
-} from './is-translations.constraint';
+} from "./is-translations.constraint";

--- a/src/validators/is-translations.constraint.ts
+++ b/src/validators/is-translations.constraint.ts
@@ -1,53 +1,48 @@
+import { Injectable, Optional } from "@nestjs/common";
 import {
+  ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
-  ValidationArguments,
-} from 'class-validator';
-import { Injectable, Optional } from '@nestjs/common';
-import { TranslatableService } from '../translatable.service';
+} from "class-validator";
+import { TranslatableService } from "../translatable.service";
 
 export interface IsTranslationsOptions {
   requiredLocales?: string[];
 }
 
-@ValidatorConstraint({ name: 'isTranslations', async: false })
+@ValidatorConstraint({ name: "isTranslations", async: false })
 @Injectable()
-export class IsTranslationsConstraint
-  implements ValidatorConstraintInterface
-{
+export class IsTranslationsConstraint implements ValidatorConstraintInterface {
   private requiredLocales: string[] = [];
 
-  constructor(
-    @Optional() private readonly service?: TranslatableService,
-  ) {}
+  constructor(@Optional() private readonly service?: TranslatableService) {}
 
   validate(value: unknown, args?: ValidationArguments): boolean {
     this.requiredLocales =
       (args?.constraints?.[0] as IsTranslationsOptions)?.requiredLocales ?? [];
 
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
       return false;
     }
 
     const entries = Object.entries(value);
     for (const [, val] of entries) {
-      if (typeof val !== 'string' && val !== null) return false;
+      if (typeof val !== "string" && val !== null) return false;
     }
 
     for (const locale of this.requiredLocales) {
       const val = (value as Record<string, unknown>)[locale];
-      if (val == null || val === '') return false;
+      if (val == null || val === "") return false;
     }
 
     return true;
   }
 
   defaultMessage(args?: ValidationArguments): string {
-    const opts =
-      (args?.constraints?.[0] as IsTranslationsOptions) ?? {};
+    const opts = (args?.constraints?.[0] as IsTranslationsOptions) ?? {};
 
     if (opts.requiredLocales?.length) {
-      return `Must be a valid translation map with required locales: ${opts.requiredLocales.join(', ')}`;
+      return `Must be a valid translation map with required locales: ${opts.requiredLocales.join(", ")}`;
     }
 
     return 'Must be a valid translation map (e.g. { "en": "Hello", "fr": "Bonjour" })';

--- a/test/is-translations.spec.ts
+++ b/test/is-translations.spec.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import 'reflect-metadata';
-import { validate } from 'class-validator';
-import { IsTranslations } from '../src/decorators/is-translations.decorator';
-import { IsTranslationsConstraint } from '../src/validators/is-translations.constraint';
+import { describe, it, expect } from "vitest";
+import "reflect-metadata";
+import { validate } from "class-validator";
+import { IsTranslations } from "../src/decorators/is-translations.decorator";
+import { IsTranslationsConstraint } from "../src/validators/is-translations.constraint";
 
 class BasicDto {
   @IsTranslations()
@@ -10,158 +10,157 @@ class BasicDto {
 }
 
 class RequiredLocalesDto {
-  @IsTranslations({ requiredLocales: ['en'] })
+  @IsTranslations({ requiredLocales: ["en"] })
   name!: Record<string, string>;
 }
 
 class MultiRequiredDto {
-  @IsTranslations({ requiredLocales: ['en', 'ar'] })
+  @IsTranslations({ requiredLocales: ["en", "ar"] })
   name!: Record<string, string>;
 }
 
 class CustomMessageDto {
-  @IsTranslations(undefined, { message: 'Invalid translations format' })
+  @IsTranslations(undefined, { message: "Invalid translations format" })
   name!: Record<string, string>;
 }
 
-describe('IsTranslations decorator', () => {
-  describe('basic validation', () => {
-    it('should pass for valid translation map', async () => {
+describe("IsTranslations decorator", () => {
+  describe("basic validation", () => {
+    it("should pass for valid translation map", async () => {
       const dto = new BasicDto();
-      dto.name = { en: 'Hello', fr: 'Bonjour' };
+      dto.name = { en: "Hello", fr: "Bonjour" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('should pass for empty object', async () => {
+    it("should pass for empty object", async () => {
       const dto = new BasicDto();
       dto.name = {};
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('should pass for null values in map', async () => {
+    it("should pass for null values in map", async () => {
       const dto = new BasicDto();
-      dto.name = { en: 'Hello', fr: null } as any;
+      dto.name = { en: "Hello", fr: null } as any;
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('should fail for string value', async () => {
+    it("should fail for string value", async () => {
       const dto = new BasicDto();
-      (dto as any).name = 'just a string';
+      (dto as any).name = "just a string";
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail for array value', async () => {
+    it("should fail for array value", async () => {
       const dto = new BasicDto();
-      (dto as any).name = ['en', 'fr'];
+      (dto as any).name = ["en", "fr"];
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail for null value', async () => {
+    it("should fail for null value", async () => {
       const dto = new BasicDto();
       (dto as any).name = null;
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail for number value', async () => {
+    it("should fail for number value", async () => {
       const dto = new BasicDto();
       (dto as any).name = 42;
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail when value contains non-string values', async () => {
+    it("should fail when value contains non-string values", async () => {
       const dto = new BasicDto();
-      (dto as any).name = { en: 'Hello', fr: 123 };
+      (dto as any).name = { en: "Hello", fr: 123 };
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
   });
 
-  describe('required locales', () => {
-    it('should pass when required locale is present', async () => {
+  describe("required locales", () => {
+    it("should pass when required locale is present", async () => {
       const dto = new RequiredLocalesDto();
-      dto.name = { en: 'Hello' };
+      dto.name = { en: "Hello" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('should fail when required locale is missing', async () => {
+    it("should fail when required locale is missing", async () => {
       const dto = new RequiredLocalesDto();
-      dto.name = { fr: 'Bonjour' };
+      dto.name = { fr: "Bonjour" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail when required locale has empty string', async () => {
+    it("should fail when required locale has empty string", async () => {
       const dto = new RequiredLocalesDto();
-      dto.name = { en: '' };
+      dto.name = { en: "" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should fail when required locale has null value', async () => {
+    it("should fail when required locale has null value", async () => {
       const dto = new RequiredLocalesDto();
       dto.name = { en: null } as any;
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
 
-    it('should validate multiple required locales', async () => {
+    it("should validate multiple required locales", async () => {
       const dto = new MultiRequiredDto();
-      dto.name = { en: 'Hello', ar: 'مرحبا' };
+      dto.name = { en: "Hello", ar: "مرحبا" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
 
-    it('should fail when one of multiple required locales is missing', async () => {
+    it("should fail when one of multiple required locales is missing", async () => {
       const dto = new MultiRequiredDto();
-      dto.name = { en: 'Hello' };
+      dto.name = { en: "Hello" };
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
     });
   });
 
-  describe('custom message', () => {
-    it('should use custom validation message', async () => {
+  describe("custom message", () => {
+    it("should use custom validation message", async () => {
       const dto = new CustomMessageDto();
-      (dto as any).name = 'invalid';
+      (dto as any).name = "invalid";
       const errors = await validate(dto);
       expect(errors).toHaveLength(1);
       expect(errors[0].constraints).toBeDefined();
-      const message = Object.values(errors[0].constraints!)[0];
-      expect(message).toBe('Invalid translations format');
+      const constraints = errors[0].constraints ?? {};
+      const message = Object.values(constraints)[0];
+      expect(message).toBe("Invalid translations format");
     });
   });
 
-  describe('IsTranslationsConstraint standalone', () => {
-    it('should validate without service injection', () => {
+  describe("IsTranslationsConstraint standalone", () => {
+    it("should validate without service injection", () => {
       const constraint = new IsTranslationsConstraint();
-      expect(constraint.validate({ en: 'Hello' })).toBe(true);
-      expect(constraint.validate('invalid')).toBe(false);
+      expect(constraint.validate({ en: "Hello" })).toBe(true);
+      expect(constraint.validate("invalid")).toBe(false);
     });
 
-    it('should return default message', () => {
+    it("should return default message", () => {
       const constraint = new IsTranslationsConstraint();
-      expect(constraint.defaultMessage()).toContain(
-        'valid translation map',
-      );
+      expect(constraint.defaultMessage()).toContain("valid translation map");
     });
 
-    it('should return message with required locales when specified', () => {
+    it("should return message with required locales when specified", () => {
       const constraint = new IsTranslationsConstraint();
       const args = {
-        constraints: [{ requiredLocales: ['en', 'ar'] }],
+        constraints: [{ requiredLocales: ["en", "ar"] }],
       } as any;
       const message = constraint.defaultMessage(args);
-      expect(message).toContain('required locales');
-      expect(message).toContain('en');
-      expect(message).toContain('ar');
+      expect(message).toContain("required locales");
+      expect(message).toContain("en");
+      expect(message).toContain("ar");
     });
   });
 });

--- a/test/translatable-query.spec.ts
+++ b/test/translatable-query.spec.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 import {
   whereTranslation,
   whereTranslationLike,
   whereLocale,
   whereLocales,
   orderByTranslation,
-} from '../src/query/translatable-query.helpers';
+} from "../src/query/translatable-query.helpers";
 
-function createMockQueryBuilder(alias: string = 'entity') {
+function createMockQueryBuilder(alias: string = "entity") {
   const qb: any = {
     alias,
     andWhere: vi.fn().mockReturnThis(),
@@ -16,49 +16,49 @@ function createMockQueryBuilder(alias: string = 'entity') {
   return qb;
 }
 
-describe('Query helpers', () => {
-  describe('whereTranslation', () => {
-    it('should add WHERE clause with jsonb extraction and exact value', () => {
-      const qb = createMockQueryBuilder('news');
+describe("Query helpers", () => {
+  describe("whereTranslation", () => {
+    it("should add WHERE clause with jsonb extraction and exact value", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereTranslation(qb, 'name', 'en', 'Hello');
+      whereTranslation(qb, "name", "en", "Hello");
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `"news"."name"->>'en' = :name_en_val`,
-        { name_en_val: 'Hello' },
+        { name_en_val: "Hello" },
       );
     });
 
-    it('should use custom alias', () => {
-      const qb = createMockQueryBuilder('news');
+    it("should use custom alias", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereTranslation(qb, 'name', 'en', 'Hello', 'n');
+      whereTranslation(qb, "name", "en", "Hello", "n");
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `"n"."name"->>'en' = :name_en_val`,
-        { name_en_val: 'Hello' },
+        { name_en_val: "Hello" },
       );
     });
   });
 
-  describe('whereTranslationLike', () => {
-    it('should add ILIKE clause for pattern matching', () => {
-      const qb = createMockQueryBuilder('news');
+  describe("whereTranslationLike", () => {
+    it("should add ILIKE clause for pattern matching", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereTranslationLike(qb, 'name', 'en', '%breaking%');
+      whereTranslationLike(qb, "name", "en", "%breaking%");
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `"news"."name"->>'en' ILIKE :name_en_like`,
-        { name_en_like: '%breaking%' },
+        { name_en_like: "%breaking%" },
       );
     });
   });
 
-  describe('whereLocale', () => {
-    it('should add IS NOT NULL clause for locale existence', () => {
-      const qb = createMockQueryBuilder('news');
+  describe("whereLocale", () => {
+    it("should add IS NOT NULL clause for locale existence", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereLocale(qb, 'name', 'en');
+      whereLocale(qb, "name", "en");
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `"news"."name"->>'en' IS NOT NULL`,
@@ -66,21 +66,21 @@ describe('Query helpers', () => {
     });
   });
 
-  describe('whereLocales', () => {
-    it('should add OR clause for multiple locale existence', () => {
-      const qb = createMockQueryBuilder('news');
+  describe("whereLocales", () => {
+    it("should add OR clause for multiple locale existence", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereLocales(qb, 'name', ['en', 'fr']);
+      whereLocales(qb, "name", ["en", "fr"]);
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `("news"."name"->>'en' IS NOT NULL OR "news"."name"->>'fr' IS NOT NULL)`,
       );
     });
 
-    it('should work with single locale', () => {
-      const qb = createMockQueryBuilder('news');
+    it("should work with single locale", () => {
+      const qb = createMockQueryBuilder("news");
 
-      whereLocales(qb, 'name', ['en']);
+      whereLocales(qb, "name", ["en"]);
 
       expect(qb.andWhere).toHaveBeenCalledWith(
         `("news"."name"->>'en' IS NOT NULL)`,
@@ -88,48 +88,42 @@ describe('Query helpers', () => {
     });
   });
 
-  describe('orderByTranslation', () => {
-    it('should add ORDER BY clause defaulting to ASC', () => {
-      const qb = createMockQueryBuilder('news');
+  describe("orderByTranslation", () => {
+    it("should add ORDER BY clause defaulting to ASC", () => {
+      const qb = createMockQueryBuilder("news");
 
-      orderByTranslation(qb, 'name', 'en');
+      orderByTranslation(qb, "name", "en");
+
+      expect(qb.addOrderBy).toHaveBeenCalledWith(`"news"."name"->>'en'`, "ASC");
+    });
+
+    it("should accept DESC order", () => {
+      const qb = createMockQueryBuilder("news");
+
+      orderByTranslation(qb, "name", "en", "DESC");
 
       expect(qb.addOrderBy).toHaveBeenCalledWith(
         `"news"."name"->>'en'`,
-        'ASC',
+        "DESC",
       );
     });
 
-    it('should accept DESC order', () => {
-      const qb = createMockQueryBuilder('news');
+    it("should use custom alias", () => {
+      const qb = createMockQueryBuilder("news");
 
-      orderByTranslation(qb, 'name', 'en', 'DESC');
+      orderByTranslation(qb, "name", "en", "ASC", "n");
 
-      expect(qb.addOrderBy).toHaveBeenCalledWith(
-        `"news"."name"->>'en'`,
-        'DESC',
-      );
-    });
-
-    it('should use custom alias', () => {
-      const qb = createMockQueryBuilder('news');
-
-      orderByTranslation(qb, 'name', 'en', 'ASC', 'n');
-
-      expect(qb.addOrderBy).toHaveBeenCalledWith(
-        `"n"."name"->>'en'`,
-        'ASC',
-      );
+      expect(qb.addOrderBy).toHaveBeenCalledWith(`"n"."name"->>'en'`, "ASC");
     });
   });
 
-  describe('chaining', () => {
-    it('should support chaining multiple helpers', () => {
-      const qb = createMockQueryBuilder('news');
+  describe("chaining", () => {
+    it("should support chaining multiple helpers", () => {
+      const qb = createMockQueryBuilder("news");
 
-      const result = whereLocale(qb, 'name', 'en');
-      whereTranslation(result, 'name', 'en', 'Hello');
-      orderByTranslation(result, 'name', 'en', 'ASC');
+      const result = whereLocale(qb, "name", "en");
+      whereTranslation(result, "name", "en", "Hello");
+      orderByTranslation(result, "name", "en", "ASC");
 
       expect(qb.andWhere).toHaveBeenCalledTimes(2);
       expect(qb.addOrderBy).toHaveBeenCalledTimes(1);

--- a/test/translatable.decorator.spec.ts
+++ b/test/translatable.decorator.spec.ts
@@ -1,23 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import 'reflect-metadata';
+import { describe, it, expect } from "vitest";
+import "reflect-metadata";
 import {
   Translatable,
   getTranslatableFields,
-} from '../src/decorators/translatable.decorator';
-import { TRANSLATABLE_METADATA_KEY } from '../src/translatable.constants';
+} from "../src/decorators/translatable.decorator";
+import { TRANSLATABLE_METADATA_KEY } from "../src/translatable.constants";
 
-describe('Translatable decorator', () => {
-  it('should register a single translatable field via metadata', () => {
+describe("Translatable decorator", () => {
+  it("should register a single translatable field via metadata", () => {
     class TestEntity {
       @Translatable()
       name: Record<string, string> = {};
     }
 
     const fields = getTranslatableFields(TestEntity);
-    expect(fields).toEqual(['name']);
+    expect(fields).toEqual(["name"]);
   });
 
-  it('should register multiple translatable fields', () => {
+  it("should register multiple translatable fields", () => {
     class TestEntity {
       @Translatable()
       name: Record<string, string> = {};
@@ -27,10 +27,10 @@ describe('Translatable decorator', () => {
     }
 
     const fields = getTranslatableFields(TestEntity);
-    expect(fields).toEqual(['name', 'description']);
+    expect(fields).toEqual(["name", "description"]);
   });
 
-  it('should not duplicate fields if decorator is applied twice', () => {
+  it("should not duplicate fields if decorator is applied twice", () => {
     class TestEntity {
       @Translatable()
       @Translatable()
@@ -38,32 +38,29 @@ describe('Translatable decorator', () => {
     }
 
     const fields = getTranslatableFields(TestEntity);
-    expect(fields).toEqual(['name']);
+    expect(fields).toEqual(["name"]);
   });
 
-  it('should return empty array for entities without translatable fields', () => {
+  it("should return empty array for entities without translatable fields", () => {
     class TestEntity {
-      slug: string = '';
+      slug: string = "";
     }
 
     const fields = getTranslatableFields(TestEntity);
     expect(fields).toEqual([]);
   });
 
-  it('should store metadata under the correct key', () => {
+  it("should store metadata under the correct key", () => {
     class TestEntity {
       @Translatable()
       title: Record<string, string> = {};
     }
 
-    const fields = Reflect.getMetadata(
-      TRANSLATABLE_METADATA_KEY,
-      TestEntity,
-    );
-    expect(fields).toEqual(['title']);
+    const fields = Reflect.getMetadata(TRANSLATABLE_METADATA_KEY, TestEntity);
+    expect(fields).toEqual(["title"]);
   });
 
-  it('should keep separate metadata per class', () => {
+  it("should keep separate metadata per class", () => {
     class EntityA {
       @Translatable()
       name: Record<string, string> = {};
@@ -77,7 +74,7 @@ describe('Translatable decorator', () => {
       body: Record<string, string> = {};
     }
 
-    expect(getTranslatableFields(EntityA)).toEqual(['name']);
-    expect(getTranslatableFields(EntityB)).toEqual(['title', 'body']);
+    expect(getTranslatableFields(EntityA)).toEqual(["name"]);
+    expect(getTranslatableFields(EntityB)).toEqual(["title", "body"]);
   });
 });

--- a/test/translatable.interceptor.spec.ts
+++ b/test/translatable.interceptor.spec.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import 'reflect-metadata';
-import { of, firstValueFrom } from 'rxjs';
-import { Test, TestingModule } from '@nestjs/testing';
-import { Translatable } from '../src/decorators/translatable.decorator';
-import { TranslatableMixin } from '../src/mixins/translatable.mixin';
-import { TranslatableInterceptor } from '../src/middleware/translatable.interceptor';
-import { TranslatableService } from '../src/translatable.service';
-import { TRANSLATABLE_OPTIONS } from '../src/translatable.constants';
-import { TranslationMap } from '../src/interfaces';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "reflect-metadata";
+import { of, firstValueFrom } from "rxjs";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Translatable } from "../src/decorators/translatable.decorator";
+import { TranslatableMixin } from "../src/mixins/translatable.mixin";
+import { TranslatableInterceptor } from "../src/middleware/translatable.interceptor";
+import { TranslatableService } from "../src/translatable.service";
+import { TRANSLATABLE_OPTIONS } from "../src/translatable.constants";
+import { TranslationMap } from "../src/interfaces";
 
 class TestProduct extends TranslatableMixin(class {}) {
   @Translatable()
@@ -16,16 +16,14 @@ class TestProduct extends TranslatableMixin(class {}) {
   @Translatable()
   description: TranslationMap = {};
 
-  slug: string = '';
+  slug: string = "";
 }
 
 function createMockContext(acceptLanguage?: string) {
   return {
     switchToHttp: () => ({
       getRequest: () => ({
-        headers: acceptLanguage
-          ? { 'accept-language': acceptLanguage }
-          : {},
+        headers: acceptLanguage ? { "accept-language": acceptLanguage } : {},
       }),
     }),
   } as any;
@@ -37,7 +35,7 @@ function createMockHandler(data: any) {
   } as any;
 }
 
-describe('TranslatableInterceptor', () => {
+describe("TranslatableInterceptor", () => {
   let interceptor: TranslatableInterceptor;
   let service: TranslatableService;
 
@@ -46,7 +44,7 @@ describe('TranslatableInterceptor', () => {
       providers: [
         {
           provide: TRANSLATABLE_OPTIONS,
-          useValue: { defaultLocale: 'en', fallbackLocale: 'en' },
+          useValue: { defaultLocale: "en", fallbackLocale: "en" },
         },
         TranslatableService,
         TranslatableInterceptor,
@@ -62,62 +60,65 @@ describe('TranslatableInterceptor', () => {
     TranslatableService.resetInstance();
   });
 
-  describe('with Accept-Language header', () => {
-    it('should resolve translatable fields to the requested locale', async () => {
+  describe("with Accept-Language header", () => {
+    it("should resolve translatable fields to the requested locale", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
-      entity.description = { en: 'A greeting', ar: 'تحية' };
-      entity.slug = 'hello';
+      entity.name = { en: "Hello", ar: "مرحبا" };
+      entity.description = { en: "A greeting", ar: "تحية" };
+      entity.slug = "hello";
 
-      const context = createMockContext('ar');
+      const context = createMockContext("ar");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('ar', () => {
+        service.runWithLocale("ar", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
         });
       });
 
-      expect(result.name).toBe('مرحبا');
-      expect(result.description).toBe('تحية');
-      expect(result.slug).toBe('hello');
+      expect(result.name).toBe("مرحبا");
+      expect(result.description).toBe("تحية");
+      expect(result.slug).toBe("hello");
     });
 
-    it('should resolve an array of entities', async () => {
+    it("should resolve an array of entities", async () => {
       const entity1 = new TestProduct();
-      entity1.name = { en: 'Hello', fr: 'Bonjour' };
-      entity1.slug = 'hello';
+      entity1.name = { en: "Hello", fr: "Bonjour" };
+      entity1.slug = "hello";
 
       const entity2 = new TestProduct();
-      entity2.name = { en: 'World', fr: 'Monde' };
-      entity2.slug = 'world';
+      entity2.name = { en: "World", fr: "Monde" };
+      entity2.slug = "world";
 
-      const context = createMockContext('fr');
+      const context = createMockContext("fr");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('fr', () => {
+        service.runWithLocale("fr", () => {
           firstValueFrom(
-            interceptor.intercept(context, createMockHandler([entity1, entity2])),
+            interceptor.intercept(
+              context,
+              createMockHandler([entity1, entity2]),
+            ),
           ).then(resolve);
         });
       });
 
       expect(result).toHaveLength(2);
-      expect(result[0].name).toBe('Bonjour');
-      expect(result[0].slug).toBe('hello');
-      expect(result[1].name).toBe('Monde');
+      expect(result[0].name).toBe("Bonjour");
+      expect(result[0].slug).toBe("hello");
+      expect(result[1].name).toBe("Monde");
     });
 
-    it('should use fallback locale when requested locale is missing', async () => {
+    it("should use fallback locale when requested locale is missing", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello' };
-      entity.slug = 'hello';
+      entity.name = { en: "Hello" };
+      entity.slug = "hello";
 
-      const context = createMockContext('de');
+      const context = createMockContext("de");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('de', () => {
+        service.runWithLocale("de", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
@@ -125,19 +126,19 @@ describe('TranslatableInterceptor', () => {
       });
 
       // Falls back to 'en' (configured fallbackLocale)
-      expect(result.name).toBe('Hello');
+      expect(result.name).toBe("Hello");
     });
 
-    it('should return null for missing translations with no fallback match', async () => {
+    it("should return null for missing translations with no fallback match", async () => {
       const entity = new TestProduct();
-      entity.name = { fr: 'Bonjour' };
-      entity.slug = 'hello';
+      entity.name = { fr: "Bonjour" };
+      entity.slug = "hello";
 
-      const context = createMockContext('de');
+      const context = createMockContext("de");
 
       // Default fallback is 'en', which is also missing
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('de', () => {
+        service.runWithLocale("de", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
@@ -147,52 +148,52 @@ describe('TranslatableInterceptor', () => {
       expect(result.name).toBeNull();
     });
 
-    it('should handle nested entity in plain object wrapper', async () => {
+    it("should handle nested entity in plain object wrapper", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
-      entity.slug = 'hello';
+      entity.name = { en: "Hello", ar: "مرحبا" };
+      entity.slug = "hello";
 
       const wrapped = { data: entity, total: 1 };
-      const context = createMockContext('ar');
+      const context = createMockContext("ar");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('ar', () => {
+        service.runWithLocale("ar", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(wrapped)),
           ).then(resolve);
         });
       });
 
-      expect(result.data.name).toBe('مرحبا');
+      expect(result.data.name).toBe("مرحبا");
       expect(result.total).toBe(1);
     });
 
-    it('should handle array of entities inside wrapper', async () => {
+    it("should handle array of entities inside wrapper", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
+      entity.name = { en: "Hello", ar: "مرحبا" };
 
       const wrapped = { data: [entity], total: 1 };
-      const context = createMockContext('ar');
+      const context = createMockContext("ar");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('ar', () => {
+        service.runWithLocale("ar", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(wrapped)),
           ).then(resolve);
         });
       });
 
-      expect(result.data[0].name).toBe('مرحبا');
+      expect(result.data[0].name).toBe("مرحبا");
       expect(result.total).toBe(1);
     });
   });
 
-  describe('without Accept-Language header', () => {
-    it('should return full JSON translation maps', async () => {
+  describe("without Accept-Language header", () => {
+    it("should return full JSON translation maps", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
-      entity.description = { en: 'A greeting', ar: 'تحية' };
-      entity.slug = 'hello';
+      entity.name = { en: "Hello", ar: "مرحبا" };
+      entity.description = { en: "A greeting", ar: "تحية" };
+      entity.slug = "hello";
 
       const context = createMockContext(); // no header
 
@@ -200,14 +201,14 @@ describe('TranslatableInterceptor', () => {
         interceptor.intercept(context, createMockHandler(entity)),
       );
 
-      expect(result.name).toEqual({ en: 'Hello', ar: 'مرحبا' });
-      expect(result.description).toEqual({ en: 'A greeting', ar: 'تحية' });
-      expect(result.slug).toBe('hello');
+      expect(result.name).toEqual({ en: "Hello", ar: "مرحبا" });
+      expect(result.description).toEqual({ en: "A greeting", ar: "تحية" });
+      expect(result.slug).toBe("hello");
     });
 
-    it('should return full JSON for array of entities', async () => {
+    it("should return full JSON for array of entities", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', fr: 'Bonjour' };
+      entity.name = { en: "Hello", fr: "Bonjour" };
 
       const context = createMockContext(); // no header
 
@@ -215,16 +216,16 @@ describe('TranslatableInterceptor', () => {
         interceptor.intercept(context, createMockHandler([entity])),
       );
 
-      expect(result[0].name).toEqual({ en: 'Hello', fr: 'Bonjour' });
+      expect(result[0].name).toEqual({ en: "Hello", fr: "Bonjour" });
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle null data', async () => {
-      const context = createMockContext('en');
+  describe("edge cases", () => {
+    it("should handle null data", async () => {
+      const context = createMockContext("en");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(null)),
           ).then(resolve);
@@ -234,41 +235,41 @@ describe('TranslatableInterceptor', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle primitive data', async () => {
-      const context = createMockContext('en');
+    it("should handle primitive data", async () => {
+      const context = createMockContext("en");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
-            interceptor.intercept(context, createMockHandler('just a string')),
+            interceptor.intercept(context, createMockHandler("just a string")),
           ).then(resolve);
         });
       });
 
-      expect(result).toBe('just a string');
+      expect(result).toBe("just a string");
     });
 
-    it('should handle plain objects without translatable metadata', async () => {
-      const context = createMockContext('en');
-      const data = { foo: 'bar', count: 42 };
+    it("should handle plain objects without translatable metadata", async () => {
+      const context = createMockContext("en");
+      const data = { foo: "bar", count: 42 };
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(data)),
           ).then(resolve);
         });
       });
 
-      expect(result).toEqual({ foo: 'bar', count: 42 });
+      expect(result).toEqual({ foo: "bar", count: 42 });
     });
 
-    it('should handle nested plain objects without translatable metadata', async () => {
-      const context = createMockContext('en');
+    it("should handle nested plain objects without translatable metadata", async () => {
+      const context = createMockContext("en");
       const data = { meta: { page: 1, limit: 10 }, count: 42 };
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(data)),
           ).then(resolve);
@@ -279,33 +280,33 @@ describe('TranslatableInterceptor', () => {
       expect(result.count).toBe(42);
     });
 
-    it('should handle translatable field with non-object value', async () => {
+    it("should handle translatable field with non-object value", async () => {
       const entity = new TestProduct();
-      (entity as any).name = 'raw string';
-      entity.slug = 'test';
+      (entity as any).name = "raw string";
+      entity.slug = "test";
 
-      const context = createMockContext('en');
+      const context = createMockContext("en");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
         });
       });
 
-      expect(result.name).toBe('raw string');
+      expect(result.name).toBe("raw string");
     });
 
-    it('should skip function properties on entities', async () => {
+    it("should skip function properties on entities", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
-      entity.slug = 'test';
+      entity.name = { en: "Hello", ar: "مرحبا" };
+      entity.slug = "test";
 
-      const context = createMockContext('ar');
+      const context = createMockContext("ar");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('ar', () => {
+        service.runWithLocale("ar", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
@@ -313,21 +314,21 @@ describe('TranslatableInterceptor', () => {
       });
 
       // Functions should be skipped, only data properties present
-      expect(result.name).toBe('مرحبا');
-      expect(result.slug).toBe('test');
+      expect(result.name).toBe("مرحبا");
+      expect(result.slug).toBe("test");
     });
 
-    it('should handle entity with own function property', async () => {
+    it("should handle entity with own function property", async () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', ar: 'مرحبا' };
-      entity.slug = 'test';
+      entity.name = { en: "Hello", ar: "مرحبا" };
+      entity.slug = "test";
       // Add an own function property (not on prototype)
       (entity as any).toJSON = () => ({ custom: true });
 
-      const context = createMockContext('ar');
+      const context = createMockContext("ar");
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('ar', () => {
+        service.runWithLocale("ar", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(entity)),
           ).then(resolve);
@@ -335,25 +336,25 @@ describe('TranslatableInterceptor', () => {
       });
 
       // Function property should be skipped
-      expect(result.name).toBe('مرحبا');
-      expect(result.slug).toBe('test');
+      expect(result.name).toBe("مرحبا");
+      expect(result.slug).toBe("test");
       expect(result.toJSON).toBeUndefined();
     });
 
-    it('should handle entity with null constructor', async () => {
-      const context = createMockContext('en');
+    it("should handle entity with null constructor", async () => {
+      const context = createMockContext("en");
       const data = Object.create(null);
-      data.foo = 'bar';
+      data.foo = "bar";
 
       const result = await new Promise<any>((resolve) => {
-        service.runWithLocale('en', () => {
+        service.runWithLocale("en", () => {
           firstValueFrom(
             interceptor.intercept(context, createMockHandler(data)),
           ).then(resolve);
         });
       });
 
-      expect(result.foo).toBe('bar');
+      expect(result.foo).toBe("bar");
     });
   });
 });

--- a/test/translatable.middleware.spec.ts
+++ b/test/translatable.middleware.spec.ts
@@ -1,15 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import 'reflect-metadata';
-import { Test, TestingModule } from '@nestjs/testing';
-import { TranslatableMiddleware } from '../src/middleware/translatable.middleware';
-import { TranslatableService } from '../src/translatable.service';
-import { TRANSLATABLE_OPTIONS } from '../src/translatable.constants';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "reflect-metadata";
+import { Test, TestingModule } from "@nestjs/testing";
+import { TranslatableMiddleware } from "../src/middleware/translatable.middleware";
+import { TranslatableService } from "../src/translatable.service";
+import { TRANSLATABLE_OPTIONS } from "../src/translatable.constants";
 
 function createMockReq(acceptLanguage?: string) {
   return {
-    headers: acceptLanguage
-      ? { 'accept-language': acceptLanguage }
-      : {},
+    headers: acceptLanguage ? { "accept-language": acceptLanguage } : {},
   } as any;
 }
 
@@ -17,7 +15,7 @@ function createMockRes() {
   return {} as any;
 }
 
-describe('TranslatableMiddleware', () => {
+describe("TranslatableMiddleware", () => {
   let middleware: TranslatableMiddleware;
   let service: TranslatableService;
 
@@ -26,7 +24,7 @@ describe('TranslatableMiddleware', () => {
       providers: [
         {
           provide: TRANSLATABLE_OPTIONS,
-          useValue: { defaultLocale: 'en', fallbackLocale: 'en' },
+          useValue: { defaultLocale: "en", fallbackLocale: "en" },
         },
         TranslatableService,
         TranslatableMiddleware,
@@ -42,8 +40,8 @@ describe('TranslatableMiddleware', () => {
     TranslatableService.resetInstance();
   });
 
-  it('should set locale from Accept-Language header', () => {
-    const req = createMockReq('ar');
+  it("should set locale from Accept-Language header", () => {
+    const req = createMockReq("ar");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -51,11 +49,11 @@ describe('TranslatableMiddleware', () => {
       capturedLocale = service.getLocale();
     });
 
-    expect(capturedLocale).toBe('ar');
+    expect(capturedLocale).toBe("ar");
   });
 
-  it('should parse first locale from comma-separated header', () => {
-    const req = createMockReq('fr,en;q=0.9,ar;q=0.8');
+  it("should parse first locale from comma-separated header", () => {
+    const req = createMockReq("fr,en;q=0.9,ar;q=0.8");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -63,11 +61,11 @@ describe('TranslatableMiddleware', () => {
       capturedLocale = service.getLocale();
     });
 
-    expect(capturedLocale).toBe('fr');
+    expect(capturedLocale).toBe("fr");
   });
 
-  it('should strip quality value from locale', () => {
-    const req = createMockReq('en-US;q=0.9');
+  it("should strip quality value from locale", () => {
+    const req = createMockReq("en-US;q=0.9");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -75,10 +73,10 @@ describe('TranslatableMiddleware', () => {
       capturedLocale = service.getLocale();
     });
 
-    expect(capturedLocale).toBe('en-US');
+    expect(capturedLocale).toBe("en-US");
   });
 
-  it('should use default locale when no Accept-Language header', () => {
+  it("should use default locale when no Accept-Language header", () => {
     const req = createMockReq();
     const res = createMockRes();
     let capturedLocale: string | undefined;
@@ -88,11 +86,11 @@ describe('TranslatableMiddleware', () => {
     });
 
     // No runWithLocale called, so it falls back to default
-    expect(capturedLocale).toBe('en');
+    expect(capturedLocale).toBe("en");
   });
 
-  it('should use default locale when Accept-Language is empty string', () => {
-    const req = createMockReq('');
+  it("should use default locale when Accept-Language is empty string", () => {
+    const req = createMockReq("");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -100,11 +98,11 @@ describe('TranslatableMiddleware', () => {
       capturedLocale = service.getLocale();
     });
 
-    expect(capturedLocale).toBe('en');
+    expect(capturedLocale).toBe("en");
   });
 
-  it('should call next()', () => {
-    const req = createMockReq('ar');
+  it("should call next()", () => {
+    const req = createMockReq("ar");
     const res = createMockRes();
     const next = vi.fn();
 
@@ -113,7 +111,7 @@ describe('TranslatableMiddleware', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
-  it('should call next() even without header', () => {
+  it("should call next() even without header", () => {
     const req = createMockReq();
     const res = createMockRes();
     const next = vi.fn();
@@ -123,20 +121,20 @@ describe('TranslatableMiddleware', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
-  it('should restore locale after request completes', () => {
-    const req = createMockReq('ar');
+  it("should restore locale after request completes", () => {
+    const req = createMockReq("ar");
     const res = createMockRes();
 
     middleware.use(req, res, () => {
-      expect(service.getLocale()).toBe('ar');
+      expect(service.getLocale()).toBe("ar");
     });
 
     // Outside the middleware context, back to default
-    expect(service.getLocale()).toBe('en');
+    expect(service.getLocale()).toBe("en");
   });
 
-  it('should handle header with only commas', () => {
-    const req = createMockReq(',,,');
+  it("should handle header with only commas", () => {
+    const req = createMockReq(",,,");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -145,11 +143,11 @@ describe('TranslatableMiddleware', () => {
     });
 
     // Empty after split → falls back to default
-    expect(capturedLocale).toBe('en');
+    expect(capturedLocale).toBe("en");
   });
 
-  it('should handle header with only semicolons', () => {
-    const req = createMockReq(';q=0.9');
+  it("should handle header with only semicolons", () => {
+    const req = createMockReq(";q=0.9");
     const res = createMockRes();
     let capturedLocale: string | undefined;
 
@@ -158,6 +156,6 @@ describe('TranslatableMiddleware', () => {
     });
 
     // Empty locale after splitting on semicolons → falls back to default
-    expect(capturedLocale).toBe('en');
+    expect(capturedLocale).toBe("en");
   });
 });

--- a/test/translatable.mixin.spec.ts
+++ b/test/translatable.mixin.spec.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import 'reflect-metadata';
-import { Test, TestingModule } from '@nestjs/testing';
-import { Translatable } from '../src/decorators/translatable.decorator';
-import { TranslatableMixin } from '../src/mixins/translatable.mixin';
-import { TranslatableService } from '../src/translatable.service';
-import { TRANSLATABLE_OPTIONS } from '../src/translatable.constants';
-import { AttributeIsNotTranslatableException } from '../src/exceptions';
-import { TranslationMap } from '../src/interfaces';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "reflect-metadata";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Translatable } from "../src/decorators/translatable.decorator";
+import { TranslatableMixin } from "../src/mixins/translatable.mixin";
+import { TranslatableService } from "../src/translatable.service";
+import { TRANSLATABLE_OPTIONS } from "../src/translatable.constants";
+import { AttributeIsNotTranslatableException } from "../src/exceptions";
+import { TranslationMap } from "../src/interfaces";
 
 class TestEntity extends TranslatableMixin(class {}) {
   @Translatable()
@@ -15,7 +15,7 @@ class TestEntity extends TranslatableMixin(class {}) {
   @Translatable()
   description: TranslationMap = {};
 
-  slug: string = '';
+  slug: string = "";
 }
 
 async function setupService(options = {}): Promise<TranslatableService> {
@@ -23,7 +23,7 @@ async function setupService(options = {}): Promise<TranslatableService> {
     providers: [
       {
         provide: TRANSLATABLE_OPTIONS,
-        useValue: { defaultLocale: 'en', fallbackLocale: 'en', ...options },
+        useValue: { defaultLocale: "en", fallbackLocale: "en", ...options },
       },
       TranslatableService,
     ],
@@ -34,7 +34,7 @@ async function setupService(options = {}): Promise<TranslatableService> {
   return svc;
 }
 
-describe('TranslatableMixin', () => {
+describe("TranslatableMixin", () => {
   let entity: TestEntity;
 
   beforeEach(() => {
@@ -45,406 +45,402 @@ describe('TranslatableMixin', () => {
     TranslatableService.resetInstance();
   });
 
-  describe('getTranslatableAttributes', () => {
-    it('should return all fields decorated with @Translatable()', () => {
+  describe("getTranslatableAttributes", () => {
+    it("should return all fields decorated with @Translatable()", () => {
       expect(entity.getTranslatableAttributes()).toEqual([
-        'name',
-        'description',
+        "name",
+        "description",
       ]);
     });
   });
 
-  describe('isTranslatableAttribute', () => {
-    it('should return true for translatable fields', () => {
-      expect(entity.isTranslatableAttribute('name')).toBe(true);
-      expect(entity.isTranslatableAttribute('description')).toBe(true);
+  describe("isTranslatableAttribute", () => {
+    it("should return true for translatable fields", () => {
+      expect(entity.isTranslatableAttribute("name")).toBe(true);
+      expect(entity.isTranslatableAttribute("description")).toBe(true);
     });
 
-    it('should return false for non-translatable fields', () => {
-      expect(entity.isTranslatableAttribute('slug')).toBe(false);
+    it("should return false for non-translatable fields", () => {
+      expect(entity.isTranslatableAttribute("slug")).toBe(false);
     });
   });
 
-  describe('setTranslation / getTranslation', () => {
-    it('should set and get a single translation', async () => {
+  describe("setTranslation / getTranslation", () => {
+    it("should set and get a single translation", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.getTranslation('name', 'en')).toBe('Hello');
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.getTranslation("name", "en")).toBe("Hello");
     });
 
-    it('should be chainable', async () => {
+    it("should be chainable", async () => {
       await setupService();
 
       const result = entity
-        .setTranslation('name', 'en', 'Hello')
-        .setTranslation('name', 'ar', 'مرحبا')
-        .setTranslation('name', 'fr', 'Bonjour');
+        .setTranslation("name", "en", "Hello")
+        .setTranslation("name", "ar", "مرحبا")
+        .setTranslation("name", "fr", "Bonjour");
 
       expect(result).toBe(entity);
-      expect(entity.getTranslation('name', 'en')).toBe('Hello');
-      expect(entity.getTranslation('name', 'ar')).toBe('مرحبا');
-      expect(entity.getTranslation('name', 'fr')).toBe('Bonjour');
+      expect(entity.getTranslation("name", "en")).toBe("Hello");
+      expect(entity.getTranslation("name", "ar")).toBe("مرحبا");
+      expect(entity.getTranslation("name", "fr")).toBe("Bonjour");
     });
 
-    it('should return null for missing translation', async () => {
+    it("should return null for missing translation", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.getTranslation('name', 'de', false)).toBeNull();
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.getTranslation("name", "de", false)).toBeNull();
     });
 
-    it('should store translation data in the property', async () => {
+    it("should store translation data in the property", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      entity.setTranslation('name', 'fr', 'Bonjour');
+      entity.setTranslation("name", "en", "Hello");
+      entity.setTranslation("name", "fr", "Bonjour");
 
-      expect(entity.name).toEqual({ en: 'Hello', fr: 'Bonjour' });
+      expect(entity.name).toEqual({ en: "Hello", fr: "Bonjour" });
     });
 
-    it('should remove translation when value is null', async () => {
+    it("should remove translation when value is null", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      entity.setTranslation('name', 'fr', null);
+      entity.setTranslation("name", "en", "Hello");
+      entity.setTranslation("name", "fr", "Bonjour");
+      entity.setTranslation("name", "fr", null);
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should remove translation when value is empty string', async () => {
+    it("should remove translation when value is empty string", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      entity.setTranslation('name', 'fr', '');
+      entity.setTranslation("name", "en", "Hello");
+      entity.setTranslation("name", "fr", "Bonjour");
+      entity.setTranslation("name", "fr", "");
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should throw for non-translatable attribute', async () => {
+    it("should throw for non-translatable attribute", async () => {
       await setupService();
 
-      expect(() => entity.setTranslation('slug', 'en', 'test')).toThrow(
+      expect(() => entity.setTranslation("slug", "en", "test")).toThrow(
         AttributeIsNotTranslatableException,
       );
-      expect(() => entity.getTranslation('slug', 'en')).toThrow(
+      expect(() => entity.getTranslation("slug", "en")).toThrow(
         AttributeIsNotTranslatableException,
       );
     });
   });
 
-  describe('fallback locale', () => {
-    it('should fall back to fallback locale when translation is missing', async () => {
-      await setupService({ fallbackLocale: 'en' });
+  describe("fallback locale", () => {
+    it("should fall back to fallback locale when translation is missing", async () => {
+      await setupService({ fallbackLocale: "en" });
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.getTranslation('name', 'de')).toBe('Hello');
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.getTranslation("name", "de")).toBe("Hello");
     });
 
-    it('should not fall back when useFallback is false', async () => {
-      await setupService({ fallbackLocale: 'en' });
+    it("should not fall back when useFallback is false", async () => {
+      await setupService({ fallbackLocale: "en" });
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.getTranslation('name', 'de', false)).toBeNull();
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.getTranslation("name", "de", false)).toBeNull();
     });
 
-    it('should fall back to any locale when fallbackAny is true', async () => {
-      await setupService({ fallbackLocale: 'de', fallbackAny: true });
+    it("should fall back to any locale when fallbackAny is true", async () => {
+      await setupService({ fallbackLocale: "de", fallbackAny: true });
 
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      expect(entity.getTranslation('name', 'en')).toBe('Bonjour');
+      entity.setTranslation("name", "fr", "Bonjour");
+      expect(entity.getTranslation("name", "en")).toBe("Bonjour");
     });
 
-    it('should not fall back to any when fallbackAny is false', async () => {
-      await setupService({ fallbackLocale: 'de', fallbackAny: false });
+    it("should not fall back to any when fallbackAny is false", async () => {
+      await setupService({ fallbackLocale: "de", fallbackAny: false });
 
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      expect(entity.getTranslation('name', 'en')).toBeNull();
+      entity.setTranslation("name", "fr", "Bonjour");
+      expect(entity.getTranslation("name", "en")).toBeNull();
     });
   });
 
-  describe('current locale', () => {
-    it('should use current locale when no locale is specified', async () => {
-      const service = await setupService({ defaultLocale: 'en' });
+  describe("current locale", () => {
+    it("should use current locale when no locale is specified", async () => {
+      const service = await setupService({ defaultLocale: "en" });
 
       entity
-        .setTranslation('name', 'en', 'Hello')
-        .setTranslation('name', 'fr', 'Bonjour');
+        .setTranslation("name", "en", "Hello")
+        .setTranslation("name", "fr", "Bonjour");
 
-      expect(entity.getTranslation('name')).toBe('Hello');
+      expect(entity.getTranslation("name")).toBe("Hello");
 
-      service.runWithLocale('fr', () => {
-        expect(entity.getTranslation('name')).toBe('Bonjour');
+      service.runWithLocale("fr", () => {
+        expect(entity.getTranslation("name")).toBe("Bonjour");
       });
     });
   });
 
-  describe('setTranslations', () => {
-    it('should set multiple translations at once', async () => {
+  describe("setTranslations", () => {
+    it("should set multiple translations at once", async () => {
       await setupService();
 
-      entity.setTranslations('name', {
-        en: 'Hello',
-        ar: 'مرحبا',
-        fr: 'Bonjour',
+      entity.setTranslations("name", {
+        en: "Hello",
+        ar: "مرحبا",
+        fr: "Bonjour",
       });
 
-      expect(entity.getTranslation('name', 'en')).toBe('Hello');
-      expect(entity.getTranslation('name', 'ar')).toBe('مرحبا');
-      expect(entity.getTranslation('name', 'fr')).toBe('Bonjour');
+      expect(entity.getTranslation("name", "en")).toBe("Hello");
+      expect(entity.getTranslation("name", "ar")).toBe("مرحبا");
+      expect(entity.getTranslation("name", "fr")).toBe("Bonjour");
     });
 
-    it('should be chainable', async () => {
+    it("should be chainable", async () => {
       await setupService();
 
-      const result = entity.setTranslations('name', { en: 'Hello' });
+      const result = entity.setTranslations("name", { en: "Hello" });
       expect(result).toBe(entity);
     });
   });
 
-  describe('getTranslations', () => {
-    it('should return all translations for a field', async () => {
+  describe("getTranslations", () => {
+    it("should return all translations for a field", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
 
-      expect(entity.getTranslations('name')).toEqual({
-        en: 'Hello',
-        fr: 'Bonjour',
+      expect(entity.getTranslations("name")).toEqual({
+        en: "Hello",
+        fr: "Bonjour",
       });
     });
 
-    it('should return all translations for all fields when no key given', async () => {
+    it("should return all translations for all fields when no key given", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello' });
-      entity.setTranslations('description', { en: 'A greeting' });
+      entity.setTranslations("name", { en: "Hello" });
+      entity.setTranslations("description", { en: "A greeting" });
 
       const result = entity.getTranslations() as Record<string, TranslationMap>;
       expect(result).toEqual({
-        name: { en: 'Hello' },
-        description: { en: 'A greeting' },
+        name: { en: "Hello" },
+        description: { en: "A greeting" },
       });
     });
 
-    it('should filter by allowed locales', async () => {
+    it("should filter by allowed locales", async () => {
       await setupService();
 
-      entity.setTranslations('name', {
-        en: 'Hello',
-        fr: 'Bonjour',
-        ar: 'مرحبا',
+      entity.setTranslations("name", {
+        en: "Hello",
+        fr: "Bonjour",
+        ar: "مرحبا",
       });
 
-      expect(entity.getTranslations('name', ['en', 'fr'])).toEqual({
-        en: 'Hello',
-        fr: 'Bonjour',
+      expect(entity.getTranslations("name", ["en", "fr"])).toEqual({
+        en: "Hello",
+        fr: "Bonjour",
       });
     });
 
-    it('should exclude null/empty values', async () => {
+    it("should exclude null/empty values", async () => {
       await setupService();
 
-      entity.name = { en: 'Hello', fr: '', ar: 'مرحبا' };
+      entity.name = { en: "Hello", fr: "", ar: "مرحبا" };
 
-      expect(entity.getTranslations('name')).toEqual({
-        en: 'Hello',
-        ar: 'مرحبا',
+      expect(entity.getTranslations("name")).toEqual({
+        en: "Hello",
+        ar: "مرحبا",
       });
     });
   });
 
-  describe('forgetTranslation', () => {
-    it('should remove a specific translation', async () => {
+  describe("forgetTranslation", () => {
+    it("should remove a specific translation", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
-      entity.forgetTranslation('name', 'fr');
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
+      entity.forgetTranslation("name", "fr");
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should be chainable', async () => {
+    it("should be chainable", async () => {
       await setupService();
 
-      entity.setTranslations('name', {
-        en: 'Hello',
-        fr: 'Bonjour',
-        ar: 'مرحبا',
+      entity.setTranslations("name", {
+        en: "Hello",
+        fr: "Bonjour",
+        ar: "مرحبا",
       });
 
       const result = entity
-        .forgetTranslation('name', 'fr')
-        .forgetTranslation('name', 'ar');
+        .forgetTranslation("name", "fr")
+        .forgetTranslation("name", "ar");
 
       expect(result).toBe(entity);
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should not throw when forgetting non-existent locale', async () => {
+    it("should not throw when forgetting non-existent locale", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
+      entity.setTranslation("name", "en", "Hello");
 
-      expect(() => entity.forgetTranslation('name', 'de')).not.toThrow();
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(() => entity.forgetTranslation("name", "de")).not.toThrow();
+      expect(entity.name).toEqual({ en: "Hello" });
     });
   });
 
-  describe('forgetAllTranslations', () => {
-    it('should remove a locale across all translatable fields', async () => {
+  describe("forgetAllTranslations", () => {
+    it("should remove a locale across all translatable fields", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
-      entity.setTranslations('description', { en: 'Greeting', fr: 'Salut' });
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
+      entity.setTranslations("description", { en: "Greeting", fr: "Salut" });
 
-      entity.forgetAllTranslations('fr');
+      entity.forgetAllTranslations("fr");
 
-      expect(entity.name).toEqual({ en: 'Hello' });
-      expect(entity.description).toEqual({ en: 'Greeting' });
+      expect(entity.name).toEqual({ en: "Hello" });
+      expect(entity.description).toEqual({ en: "Greeting" });
     });
 
-    it('should be chainable', async () => {
+    it("should be chainable", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
-      const result = entity.forgetAllTranslations('fr');
-      expect(result).toBe(entity);
-    });
-  });
-
-  describe('replaceTranslations', () => {
-    it('should replace all translations for a field', async () => {
-      await setupService();
-
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
-      entity.replaceTranslations('name', { ar: 'مرحبا', de: 'Hallo' });
-
-      expect(entity.name).toEqual({ ar: 'مرحبا', de: 'Hallo' });
-    });
-
-    it('should be chainable', async () => {
-      await setupService();
-
-      const result = entity.replaceTranslations('name', { en: 'Hi' });
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
+      const result = entity.forgetAllTranslations("fr");
       expect(result).toBe(entity);
     });
   });
 
-  describe('hasTranslation', () => {
-    it('should return true when translation exists', async () => {
+  describe("replaceTranslations", () => {
+    it("should replace all translations for a field", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.hasTranslation('name', 'en')).toBe(true);
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
+      entity.replaceTranslations("name", { ar: "مرحبا", de: "Hallo" });
+
+      expect(entity.name).toEqual({ ar: "مرحبا", de: "Hallo" });
     });
 
-    it('should return false when translation is missing', async () => {
+    it("should be chainable", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.hasTranslation('name', 'fr')).toBe(false);
+      const result = entity.replaceTranslations("name", { en: "Hi" });
+      expect(result).toBe(entity);
+    });
+  });
+
+  describe("hasTranslation", () => {
+    it("should return true when translation exists", async () => {
+      await setupService();
+
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.hasTranslation("name", "en")).toBe(true);
     });
 
-    it('should use current locale when no locale specified', async () => {
-      const service = await setupService({ defaultLocale: 'en' });
+    it("should return false when translation is missing", async () => {
+      await setupService();
 
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.hasTranslation('name')).toBe(true);
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.hasTranslation("name", "fr")).toBe(false);
+    });
 
-      service.runWithLocale('fr', () => {
-        expect(entity.hasTranslation('name')).toBe(false);
+    it("should use current locale when no locale specified", async () => {
+      const service = await setupService({ defaultLocale: "en" });
+
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.hasTranslation("name")).toBe(true);
+
+      service.runWithLocale("fr", () => {
+        expect(entity.hasTranslation("name")).toBe(false);
       });
     });
   });
 
-  describe('getTranslatedLocales', () => {
-    it('should return locales that have translations', async () => {
+  describe("getTranslatedLocales", () => {
+    it("should return locales that have translations", async () => {
       await setupService();
 
-      entity.setTranslations('name', {
-        en: 'Hello',
-        fr: 'Bonjour',
-        ar: 'مرحبا',
+      entity.setTranslations("name", {
+        en: "Hello",
+        fr: "Bonjour",
+        ar: "مرحبا",
       });
 
-      expect(entity.getTranslatedLocales('name')).toEqual([
-        'en',
-        'fr',
-        'ar',
-      ]);
+      expect(entity.getTranslatedLocales("name")).toEqual(["en", "fr", "ar"]);
     });
 
-    it('should exclude empty values', async () => {
+    it("should exclude empty values", async () => {
       await setupService();
 
-      entity.name = { en: 'Hello', fr: '', ar: 'مرحبا' };
+      entity.name = { en: "Hello", fr: "", ar: "مرحبا" };
 
-      expect(entity.getTranslatedLocales('name')).toEqual(['en', 'ar']);
+      expect(entity.getTranslatedLocales("name")).toEqual(["en", "ar"]);
     });
   });
 
-  describe('locales', () => {
-    it('should return union of locales across all fields', async () => {
+  describe("locales", () => {
+    it("should return union of locales across all fields", async () => {
       await setupService();
 
-      entity.setTranslations('name', { en: 'Hello', fr: 'Bonjour' });
-      entity.setTranslations('description', { en: 'Greeting', ar: 'تحية' });
+      entity.setTranslations("name", { en: "Hello", fr: "Bonjour" });
+      entity.setTranslations("description", { en: "Greeting", ar: "تحية" });
 
       const result = entity.locales();
-      expect(result.sort()).toEqual(['ar', 'en', 'fr']);
+      expect(result.sort()).toEqual(["ar", "en", "fr"]);
     });
 
-    it('should return empty array when no translations exist', () => {
+    it("should return empty array when no translations exist", () => {
       expect(entity.locales()).toEqual([]);
     });
   });
 
-  describe('without service (standalone)', () => {
-    it('should work without TranslatableService initialized', () => {
-      entity.setTranslation('name', 'en', 'Hello');
-      expect(entity.getTranslation('name', 'en')).toBe('Hello');
+  describe("without service (standalone)", () => {
+    it("should work without TranslatableService initialized", () => {
+      entity.setTranslation("name", "en", "Hello");
+      expect(entity.getTranslation("name", "en")).toBe("Hello");
     });
 
-    it('should use first available locale as fallback without service', () => {
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      expect(entity.getTranslation('name', 'en')).toBe('Bonjour');
+    it("should use first available locale as fallback without service", () => {
+      entity.setTranslation("name", "fr", "Bonjour");
+      expect(entity.getTranslation("name", "en")).toBe("Bonjour");
     });
 
-    it('should return null for missing translation without fallback and without service', () => {
-      entity.setTranslation('name', 'fr', 'Bonjour');
-      expect(entity.getTranslation('name', 'en', false)).toBeNull();
+    it("should return null for missing translation without fallback and without service", () => {
+      entity.setTranslation("name", "fr", "Bonjour");
+      expect(entity.getTranslation("name", "en", false)).toBeNull();
     });
 
     it('should default to "en" locale when no locale arg and no service', () => {
-      entity.setTranslation('name', 'en', 'English');
+      entity.setTranslation("name", "en", "English");
       // No locale argument, no service → defaults to 'en'
-      expect(entity.getTranslation('name')).toBe('English');
+      expect(entity.getTranslation("name")).toBe("English");
     });
 
     it('should default to "en" locale for hasTranslation without locale or service', () => {
-      entity.setTranslation('name', 'en', 'Hello');
+      entity.setTranslation("name", "en", "Hello");
       // No locale argument, no service → defaults to 'en'
-      expect(entity.hasTranslation('name')).toBe(true);
+      expect(entity.hasTranslation("name")).toBe(true);
     });
 
     it('should return false for hasTranslation when "en" default is missing', () => {
-      entity.setTranslation('name', 'fr', 'Bonjour');
+      entity.setTranslation("name", "fr", "Bonjour");
       // No locale argument, no service → defaults to 'en', which is missing
-      expect(entity.hasTranslation('name')).toBe(false);
+      expect(entity.hasTranslation("name")).toBe(false);
     });
 
-    it('should return null when no translations exist and no service (fallback path)', () => {
+    it("should return null when no translations exist and no service (fallback path)", () => {
       // No translations set at all, no service
       // Tests line 68: translatedLocales[0] ?? requestedLocale (empty array → requestedLocale)
-      expect(entity.getTranslation('name', 'en')).toBeNull();
+      expect(entity.getTranslation("name", "en")).toBeNull();
     });
 
-    it('should return empty array for getTranslatableAttributes on class without decorators', () => {
+    it("should return empty array for getTranslatableAttributes on class without decorators", () => {
       class Plain extends TranslatableMixin(class {}) {
-        title: string = '';
+        title: string = "";
       }
       const plain = new Plain();
       // No @Translatable() decorators → Reflect.getMetadata returns undefined → || []
@@ -452,49 +448,49 @@ describe('TranslatableMixin', () => {
     });
   });
 
-  describe('zero value handling', () => {
-    it('should preserve zero string as a valid translation', async () => {
+  describe("zero value handling", () => {
+    it("should preserve zero string as a valid translation", async () => {
       await setupService();
 
-      entity.setTranslation('name', 'en', '0');
-      expect(entity.getTranslation('name', 'en')).toBe('0');
-      expect(entity.hasTranslation('name', 'en')).toBe(true);
+      entity.setTranslation("name", "en", "0");
+      expect(entity.getTranslation("name", "en")).toBe("0");
+      expect(entity.hasTranslation("name", "en")).toBe(true);
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle entity with null property', async () => {
+  describe("edge cases", () => {
+    it("should handle entity with null property", async () => {
       await setupService();
 
       (entity as any).name = null;
-      expect(entity.getTranslation('name', 'en', false)).toBeNull();
+      expect(entity.getTranslation("name", "en", false)).toBeNull();
     });
 
-    it('should handle entity with undefined property', async () => {
+    it("should handle entity with undefined property", async () => {
       await setupService();
 
       (entity as any).name = undefined;
-      expect(entity.getTranslation('name', 'en', false)).toBeNull();
+      expect(entity.getTranslation("name", "en", false)).toBeNull();
     });
 
-    it('should work with multiple independent entities', async () => {
+    it("should work with multiple independent entities", async () => {
       await setupService();
 
       const entity1 = new TestEntity();
       const entity2 = new TestEntity();
 
-      entity1.setTranslation('name', 'en', 'First');
-      entity2.setTranslation('name', 'en', 'Second');
+      entity1.setTranslation("name", "en", "First");
+      entity2.setTranslation("name", "en", "Second");
 
-      expect(entity1.getTranslation('name', 'en')).toBe('First');
-      expect(entity2.getTranslation('name', 'en')).toBe('Second');
+      expect(entity1.getTranslation("name", "en")).toBe("First");
+      expect(entity2.getTranslation("name", "en")).toBe("Second");
     });
 
-    it('should return empty map when field value is an array', async () => {
+    it("should return empty map when field value is an array", async () => {
       await setupService();
 
-      (entity as any).name = ['not', 'an', 'object'];
-      expect(entity.getTranslations('name')).toEqual({});
+      (entity as any).name = ["not", "an", "object"];
+      expect(entity.getTranslations("name")).toEqual({});
     });
   });
 });

--- a/test/translatable.module.spec.ts
+++ b/test/translatable.module.spec.ts
@@ -1,46 +1,46 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import 'reflect-metadata';
-import { Module } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
-import { TranslatableModule } from '../src/translatable.module';
-import { TranslatableService } from '../src/translatable.service';
-import { TranslatableSubscriber } from '../src/translatable.subscriber';
-import { IsTranslationsConstraint } from '../src/validators';
+import { describe, it, expect, afterEach } from "vitest";
+import "reflect-metadata";
+import { Module } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { TranslatableModule } from "../src/translatable.module";
+import { TranslatableService } from "../src/translatable.service";
+import { TranslatableSubscriber } from "../src/translatable.subscriber";
+import { IsTranslationsConstraint } from "../src/validators";
 
-describe('TranslatableModule', () => {
+describe("TranslatableModule", () => {
   afterEach(() => {
     TranslatableService.resetInstance();
   });
 
-  describe('forRoot', () => {
-    it('should create module with default options', async () => {
+  describe("forRoot", () => {
+    it("should create module with default options", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [TranslatableModule.forRoot()],
       }).compile();
 
       const service = module.get<TranslatableService>(TranslatableService);
       expect(service).toBeDefined();
-      expect(service.getDefaultLocale()).toBe('en');
+      expect(service.getDefaultLocale()).toBe("en");
     });
 
-    it('should create module with custom options', async () => {
+    it("should create module with custom options", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [
           TranslatableModule.forRoot({
-            defaultLocale: 'ar',
-            fallbackLocale: 'en',
+            defaultLocale: "ar",
+            fallbackLocale: "en",
             fallbackAny: true,
           }),
         ],
       }).compile();
 
       const service = module.get<TranslatableService>(TranslatableService);
-      expect(service.getDefaultLocale()).toBe('ar');
-      expect(service.getFallbackLocale()).toBe('en');
+      expect(service.getDefaultLocale()).toBe("ar");
+      expect(service.getFallbackLocale()).toBe("en");
       expect(service.getFallbackAny()).toBe(true);
     });
 
-    it('should export TranslatableService', async () => {
+    it("should export TranslatableService", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [TranslatableModule.forRoot()],
       }).compile();
@@ -50,7 +50,7 @@ describe('TranslatableModule', () => {
       ).toBeDefined();
     });
 
-    it('should export TranslatableSubscriber', async () => {
+    it("should export TranslatableSubscriber", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [TranslatableModule.forRoot()],
       }).compile();
@@ -60,7 +60,7 @@ describe('TranslatableModule', () => {
       ).toBeDefined();
     });
 
-    it('should export IsTranslationsConstraint', async () => {
+    it("should export IsTranslationsConstraint", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [TranslatableModule.forRoot()],
       }).compile();
@@ -70,37 +70,35 @@ describe('TranslatableModule', () => {
       ).toBeDefined();
     });
 
-    it('should be a global module', () => {
+    it("should be a global module", () => {
       const dynamicModule = TranslatableModule.forRoot();
       expect(dynamicModule.global).toBe(true);
     });
   });
 
-  describe('forRootAsync', () => {
-    it('should create module with async factory', async () => {
+  describe("forRootAsync", () => {
+    it("should create module with async factory", async () => {
       const module: TestingModule = await Test.createTestingModule({
         imports: [
           TranslatableModule.forRootAsync({
             useFactory: () => ({
-              defaultLocale: 'fr',
-              fallbackLocale: 'en',
+              defaultLocale: "fr",
+              fallbackLocale: "en",
             }),
           }),
         ],
       }).compile();
 
       const service = module.get<TranslatableService>(TranslatableService);
-      expect(service.getDefaultLocale()).toBe('fr');
-      expect(service.getFallbackLocale()).toBe('en');
+      expect(service.getDefaultLocale()).toBe("fr");
+      expect(service.getFallbackLocale()).toBe("en");
     });
 
-    it('should support inject parameter', async () => {
-      const CONFIG_TOKEN = 'APP_CONFIG';
+    it("should support inject parameter", async () => {
+      const CONFIG_TOKEN = "APP_CONFIG";
 
       @Module({
-        providers: [
-          { provide: CONFIG_TOKEN, useValue: { locale: 'de' } },
-        ],
+        providers: [{ provide: CONFIG_TOKEN, useValue: { locale: "de" } }],
         exports: [CONFIG_TOKEN],
       })
       class ConfigModule {}
@@ -118,10 +116,10 @@ describe('TranslatableModule', () => {
       }).compile();
 
       const service = module.get<TranslatableService>(TranslatableService);
-      expect(service.getDefaultLocale()).toBe('de');
+      expect(service.getDefaultLocale()).toBe("de");
     });
 
-    it('should be a global module', () => {
+    it("should be a global module", () => {
       const dynamicModule = TranslatableModule.forRootAsync({
         useFactory: () => ({}),
       });

--- a/test/translatable.service.spec.ts
+++ b/test/translatable.service.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import 'reflect-metadata';
-import { Test, TestingModule } from '@nestjs/testing';
-import { TranslatableService } from '../src/translatable.service';
-import { TRANSLATABLE_OPTIONS } from '../src/translatable.constants';
-import { TranslatableModuleOptions } from '../src/interfaces';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "reflect-metadata";
+import { Test, TestingModule } from "@nestjs/testing";
+import { TranslatableService } from "../src/translatable.service";
+import { TRANSLATABLE_OPTIONS } from "../src/translatable.constants";
+import { TranslatableModuleOptions } from "../src/interfaces";
 
-describe('TranslatableService', () => {
+describe("TranslatableService", () => {
   let service: TranslatableService;
 
   async function createService(
@@ -18,7 +18,7 @@ describe('TranslatableService', () => {
     ];
 
     if (eventEmitter) {
-      providers.push({ provide: 'EventEmitter2', useValue: eventEmitter });
+      providers.push({ provide: "EventEmitter2", useValue: eventEmitter });
     }
 
     const module: TestingModule = await Test.createTestingModule({
@@ -34,166 +34,166 @@ describe('TranslatableService', () => {
     TranslatableService.resetInstance();
   });
 
-  describe('initialization', () => {
-    it('should use default values when no options provided', async () => {
+  describe("initialization", () => {
+    it("should use default values when no options provided", async () => {
       service = await createService();
 
-      expect(service.getDefaultLocale()).toBe('en');
-      expect(service.getFallbackLocale()).toBe('en');
+      expect(service.getDefaultLocale()).toBe("en");
+      expect(service.getFallbackLocale()).toBe("en");
       expect(service.getFallbackAny()).toBe(false);
     });
 
-    it('should use provided options', async () => {
+    it("should use provided options", async () => {
       service = await createService({
-        defaultLocale: 'ar',
-        fallbackLocale: 'fr',
+        defaultLocale: "ar",
+        fallbackLocale: "fr",
         fallbackAny: true,
       });
 
-      expect(service.getDefaultLocale()).toBe('ar');
-      expect(service.getFallbackLocale()).toBe('fr');
+      expect(service.getDefaultLocale()).toBe("ar");
+      expect(service.getFallbackLocale()).toBe("fr");
       expect(service.getFallbackAny()).toBe(true);
     });
 
-    it('should fallback locale to defaultLocale when not specified', async () => {
-      service = await createService({ defaultLocale: 'fr' });
+    it("should fallback locale to defaultLocale when not specified", async () => {
+      service = await createService({ defaultLocale: "fr" });
 
-      expect(service.getFallbackLocale()).toBe('fr');
+      expect(service.getFallbackLocale()).toBe("fr");
     });
 
-    it('should set static instance on module init', async () => {
+    it("should set static instance on module init", async () => {
       service = await createService();
 
       expect(TranslatableService.getInstance()).toBe(service);
     });
   });
 
-  describe('locale management', () => {
+  describe("locale management", () => {
     beforeEach(async () => {
-      service = await createService({ defaultLocale: 'en' });
+      service = await createService({ defaultLocale: "en" });
     });
 
-    it('should return default locale when no context is set', () => {
-      expect(service.getLocale()).toBe('en');
+    it("should return default locale when no context is set", () => {
+      expect(service.getLocale()).toBe("en");
     });
 
-    it('should return context locale inside runWithLocale', () => {
-      service.runWithLocale('fr', () => {
-        expect(service.getLocale()).toBe('fr');
+    it("should return context locale inside runWithLocale", () => {
+      service.runWithLocale("fr", () => {
+        expect(service.getLocale()).toBe("fr");
       });
     });
 
-    it('should restore locale after runWithLocale completes', () => {
-      service.runWithLocale('ar', () => {
+    it("should restore locale after runWithLocale completes", () => {
+      service.runWithLocale("ar", () => {
         // inside context
       });
-      expect(service.getLocale()).toBe('en');
+      expect(service.getLocale()).toBe("en");
     });
 
-    it('should support nested runWithLocale calls', () => {
-      service.runWithLocale('fr', () => {
-        expect(service.getLocale()).toBe('fr');
+    it("should support nested runWithLocale calls", () => {
+      service.runWithLocale("fr", () => {
+        expect(service.getLocale()).toBe("fr");
 
-        service.runWithLocale('ar', () => {
-          expect(service.getLocale()).toBe('ar');
+        service.runWithLocale("ar", () => {
+          expect(service.getLocale()).toBe("ar");
         });
 
-        expect(service.getLocale()).toBe('fr');
+        expect(service.getLocale()).toBe("fr");
       });
     });
 
-    it('should return value from runWithLocale callback', () => {
-      const result = service.runWithLocale('fr', () => 'hello');
-      expect(result).toBe('hello');
+    it("should return value from runWithLocale callback", () => {
+      const result = service.runWithLocale("fr", () => "hello");
+      expect(result).toBe("hello");
     });
   });
 
-  describe('resolveLocale', () => {
-    it('should return requested locale when it exists', async () => {
-      service = await createService({ fallbackLocale: 'en' });
+  describe("resolveLocale", () => {
+    it("should return requested locale when it exists", async () => {
+      service = await createService({ fallbackLocale: "en" });
 
-      const result = service.resolveLocale('fr', ['en', 'fr', 'ar'], true);
-      expect(result).toBe('fr');
+      const result = service.resolveLocale("fr", ["en", "fr", "ar"], true);
+      expect(result).toBe("fr");
     });
 
-    it('should fall back to fallback locale when requested is missing', async () => {
-      service = await createService({ fallbackLocale: 'en' });
+    it("should fall back to fallback locale when requested is missing", async () => {
+      service = await createService({ fallbackLocale: "en" });
 
-      const result = service.resolveLocale('de', ['en', 'fr'], true);
-      expect(result).toBe('en');
+      const result = service.resolveLocale("de", ["en", "fr"], true);
+      expect(result).toBe("en");
     });
 
-    it('should return requested locale without fallback when useFallback is false', async () => {
-      service = await createService({ fallbackLocale: 'en' });
+    it("should return requested locale without fallback when useFallback is false", async () => {
+      service = await createService({ fallbackLocale: "en" });
 
-      const result = service.resolveLocale('de', ['en', 'fr'], false);
-      expect(result).toBe('de');
+      const result = service.resolveLocale("de", ["en", "fr"], false);
+      expect(result).toBe("de");
     });
 
-    it('should fall back to any available locale when fallbackAny is true', async () => {
+    it("should fall back to any available locale when fallbackAny is true", async () => {
       service = await createService({
-        fallbackLocale: 'de',
+        fallbackLocale: "de",
         fallbackAny: true,
       });
 
-      const result = service.resolveLocale('es', ['fr', 'ar'], true);
-      expect(result).toBe('fr');
+      const result = service.resolveLocale("es", ["fr", "ar"], true);
+      expect(result).toBe("fr");
     });
 
-    it('should not fall back to any when fallbackAny is false', async () => {
+    it("should not fall back to any when fallbackAny is false", async () => {
       service = await createService({
-        fallbackLocale: 'de',
+        fallbackLocale: "de",
         fallbackAny: false,
       });
 
-      const result = service.resolveLocale('es', ['fr', 'ar'], true);
-      expect(result).toBe('es');
+      const result = service.resolveLocale("es", ["fr", "ar"], true);
+      expect(result).toBe("es");
     });
 
-    it('should return requested locale when translatedLocales is empty', async () => {
+    it("should return requested locale when translatedLocales is empty", async () => {
       service = await createService({ fallbackAny: true });
 
-      const result = service.resolveLocale('fr', [], true);
-      expect(result).toBe('fr');
+      const result = service.resolveLocale("fr", [], true);
+      expect(result).toBe("fr");
     });
   });
 
-  describe('event emission', () => {
-    it('should emit event when eventEmitter is available', async () => {
+  describe("event emission", () => {
+    it("should emit event when eventEmitter is available", async () => {
       const emitFn = vi.fn();
       const mockEmitter = { emit: emitFn };
 
       service = await createService({}, mockEmitter);
 
-      service.emitTranslationSet({}, 'name', 'en', null, 'Hello');
+      service.emitTranslationSet({}, "name", "en", null, "Hello");
 
       expect(emitFn).toHaveBeenCalledOnce();
       expect(emitFn).toHaveBeenCalledWith(
-        'translatable.translation-set',
+        "translatable.translation-set",
         expect.objectContaining({
-          key: 'name',
-          locale: 'en',
+          key: "name",
+          locale: "en",
           oldValue: null,
-          newValue: 'Hello',
+          newValue: "Hello",
         }),
       );
     });
 
-    it('should not throw when eventEmitter is not available', async () => {
+    it("should not throw when eventEmitter is not available", async () => {
       service = await createService();
 
       expect(() => {
-        service.emitTranslationSet({}, 'name', 'en', null, 'Hello');
+        service.emitTranslationSet({}, "name", "en", null, "Hello");
       }).not.toThrow();
     });
   });
 
-  describe('static instance', () => {
-    it('should return null before initialization', () => {
+  describe("static instance", () => {
+    it("should return null before initialization", () => {
       expect(TranslatableService.getInstance()).toBeNull();
     });
 
-    it('should reset instance', async () => {
+    it("should reset instance", async () => {
       service = await createService();
       expect(TranslatableService.getInstance()).toBe(service);
 

--- a/test/translatable.subscriber.spec.ts
+++ b/test/translatable.subscriber.spec.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import 'reflect-metadata';
-import { Translatable } from '../src/decorators/translatable.decorator';
-import { TranslatableSubscriber } from '../src/translatable.subscriber';
-import { TranslationMap } from '../src/interfaces';
+import { describe, it, expect, beforeEach } from "vitest";
+import "reflect-metadata";
+import { Translatable } from "../src/decorators/translatable.decorator";
+import { TranslatableSubscriber } from "../src/translatable.subscriber";
+import { TranslationMap } from "../src/interfaces";
 
 class TestProduct {
   @Translatable()
@@ -11,27 +11,27 @@ class TestProduct {
   @Translatable()
   description: TranslationMap | string | null = {};
 
-  slug: string = '';
+  slug: string = "";
 }
 
-describe('TranslatableSubscriber', () => {
+describe("TranslatableSubscriber", () => {
   let subscriber: TranslatableSubscriber;
 
   beforeEach(() => {
     subscriber = new TranslatableSubscriber();
   });
 
-  describe('afterLoad', () => {
-    it('should parse JSON string fields into objects', () => {
+  describe("afterLoad", () => {
+    it("should parse JSON string fields into objects", () => {
       const entity = new TestProduct();
       entity.name = '{"en":"Hello","fr":"Bonjour"}';
 
       subscriber.afterLoad(entity);
 
-      expect(entity.name).toEqual({ en: 'Hello', fr: 'Bonjour' });
+      expect(entity.name).toEqual({ en: "Hello", fr: "Bonjour" });
     });
 
-    it('should set null fields to empty object', () => {
+    it("should set null fields to empty object", () => {
       const entity = new TestProduct();
       entity.name = null;
 
@@ -40,129 +40,129 @@ describe('TranslatableSubscriber', () => {
       expect(entity.name).toEqual({});
     });
 
-    it('should leave valid objects as-is', () => {
+    it("should leave valid objects as-is", () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello' };
+      entity.name = { en: "Hello" };
 
       subscriber.afterLoad(entity);
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should set invalid JSON strings to empty object', () => {
+    it("should set invalid JSON strings to empty object", () => {
       const entity = new TestProduct();
-      entity.name = 'not-json';
+      entity.name = "not-json";
 
       subscriber.afterLoad(entity);
 
       expect(entity.name).toEqual({});
     });
 
-    it('should not affect non-translatable fields', () => {
+    it("should not affect non-translatable fields", () => {
       const entity = new TestProduct();
-      entity.slug = 'hello-world';
+      entity.slug = "hello-world";
 
       subscriber.afterLoad(entity);
 
-      expect(entity.slug).toBe('hello-world');
+      expect(entity.slug).toBe("hello-world");
     });
   });
 
-  describe('beforeInsert', () => {
-    it('should strip null/empty values from translation maps', () => {
+  describe("beforeInsert", () => {
+    it("should strip null/empty values from translation maps", () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', fr: '', ar: 'مرحبا' } as any;
+      entity.name = { en: "Hello", fr: "", ar: "مرحبا" } as any;
 
       subscriber.beforeInsert({ entity } as any);
 
-      expect(entity.name).toEqual({ en: 'Hello', ar: 'مرحبا' });
+      expect(entity.name).toEqual({ en: "Hello", ar: "مرحبا" });
     });
 
-    it('should preserve valid translations', () => {
+    it("should preserve valid translations", () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', fr: 'Bonjour' };
+      entity.name = { en: "Hello", fr: "Bonjour" };
 
       subscriber.beforeInsert({ entity } as any);
 
-      expect(entity.name).toEqual({ en: 'Hello', fr: 'Bonjour' });
+      expect(entity.name).toEqual({ en: "Hello", fr: "Bonjour" });
     });
 
-    it('should handle zero string values', () => {
+    it("should handle zero string values", () => {
       const entity = new TestProduct();
-      entity.name = { en: '0', fr: 'Bonjour' };
+      entity.name = { en: "0", fr: "Bonjour" };
 
       subscriber.beforeInsert({ entity } as any);
 
-      expect(entity.name).toEqual({ en: '0', fr: 'Bonjour' });
+      expect(entity.name).toEqual({ en: "0", fr: "Bonjour" });
     });
   });
 
-  describe('beforeUpdate', () => {
-    it('should strip null/empty values from translation maps', () => {
+  describe("beforeUpdate", () => {
+    it("should strip null/empty values from translation maps", () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', fr: '' } as any;
+      entity.name = { en: "Hello", fr: "" } as any;
 
       subscriber.beforeUpdate({ entity } as any);
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should handle missing entity gracefully', () => {
+    it("should handle missing entity gracefully", () => {
       expect(() => {
         subscriber.beforeUpdate({ entity: undefined } as any);
       }).not.toThrow();
     });
   });
 
-  describe('non-translatable entity', () => {
-    it('should not affect entities without @Translatable fields', () => {
+  describe("non-translatable entity", () => {
+    it("should not affect entities without @Translatable fields", () => {
       class PlainEntity {
-        name: string = 'hello';
+        name: string = "hello";
       }
 
       const entity = new PlainEntity();
       subscriber.afterLoad(entity);
-      expect(entity.name).toBe('hello');
+      expect(entity.name).toBe("hello");
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle null entity in getTranslatableFields', () => {
+  describe("edge cases", () => {
+    it("should handle null entity in getTranslatableFields", () => {
       // afterLoad with null — should not throw
       expect(() => subscriber.afterLoad(null as any)).not.toThrow();
     });
 
-    it('should handle entity without constructor', () => {
+    it("should handle entity without constructor", () => {
       const entity = Object.create(null);
       expect(() => subscriber.afterLoad(entity)).not.toThrow();
     });
 
-    it('should handle null values in serialization (beforeInsert)', () => {
+    it("should handle null values in serialization (beforeInsert)", () => {
       const entity = new TestProduct();
-      entity.name = { en: 'Hello', fr: null } as any;
+      entity.name = { en: "Hello", fr: null } as any;
 
       subscriber.beforeInsert({ entity } as any);
 
-      expect(entity.name).toEqual({ en: 'Hello' });
+      expect(entity.name).toEqual({ en: "Hello" });
     });
 
-    it('should skip non-object translatable fields during serialization', () => {
+    it("should skip non-object translatable fields during serialization", () => {
       const entity = new TestProduct();
-      (entity as any).name = 'plain string';
+      (entity as any).name = "plain string";
 
       subscriber.beforeInsert({ entity } as any);
 
       // Non-object values are left as-is
-      expect(entity.name).toBe('plain string');
+      expect(entity.name).toBe("plain string");
     });
 
-    it('should skip array translatable fields during serialization', () => {
+    it("should skip array translatable fields during serialization", () => {
       const entity = new TestProduct();
-      (entity as any).name = ['a', 'b'];
+      (entity as any).name = ["a", "b"];
 
       subscriber.beforeInsert({ entity } as any);
 
-      expect(entity.name).toEqual(['a', 'b']);
+      expect(entity.name).toEqual(["a", "b"]);
     });
   });
 });


### PR DESCRIPTION
Standardizes all string literals to use double quotes instead of single quotes throughout the TypeScript source and test files, improving code consistency and readability.

Updates type signature in decorator to accept symbol property names, enhancing type safety by converting symbols to strings where needed.

Refines function type constraint in translatable decorator to use abstract constructor syntax for better type accuracy.