### PR TITLE
Add fallback locale chain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ import { TranslatableModule } from "@nestbolt/translatable";
     }),
     TranslatableModule.forRoot({
       defaultLocale: "en",
-      fallbackLocale: "en",
+      fallbackLocales: ["en"],
     }),
   ],
 })
@@ -198,7 +198,7 @@ import {
   imports: [
     TranslatableModule.forRoot({
       defaultLocale: "en",
-      fallbackLocale: "en",
+      fallbackLocales: ["en"],
     }),
   ],
 })
@@ -233,10 +233,22 @@ export class ProductController {
 
 ### Fallback Behavior
 
-When the requested locale is missing for a field, the interceptor falls back to:
-1. The configured `fallbackLocale` (default: `'en'`)
-2. Any available locale (if `fallbackAny: true` is configured)
-3. `null` if no translation is found
+When the requested locale is missing for a field, the system tries each locale in the `fallbackLocales` chain in order:
+
+```typescript
+TranslatableModule.forRoot({
+  fallbackLocales: ['en', 'fr', 'ar'],  // tries each in order
+})
+
+// Request 'de', entity has { fr: 'Bonjour', ar: 'مرحبا' }
+entity.getTranslation('name', 'de'); // 'Bonjour' — skipped 'en', found 'fr'
+```
+
+Resolution order:
+1. The requested locale
+2. Each locale in `fallbackLocales` in order (default: `['en']`)
+3. Any available locale (if `fallbackAny: true` is configured)
+4. `null` if no translation is found
 
 ### Wrapped Responses
 
@@ -261,7 +273,7 @@ async findAll() {
 ```typescript
 TranslatableModule.forRoot({
   defaultLocale: "en",
-  fallbackLocale: "en",
+  fallbackLocales: ["en", "fr", "ar"],
   fallbackAny: false,
 });
 ```
@@ -273,7 +285,7 @@ TranslatableModule.forRootAsync({
   imports: [ConfigModule],
   useFactory: (config: ConfigService) => ({
     defaultLocale: config.get("DEFAULT_LOCALE"),
-    fallbackLocale: config.get("FALLBACK_LOCALE"),
+    fallbackLocales: config.get("FALLBACK_LOCALES"),
   }),
   inject: [ConfigService],
 });
@@ -400,7 +412,8 @@ export class MyService {
 | -------------------------------------------------- | -------- | ------------------------------------------------------ |
 | `getLocale()`                                      | `string` | Get current locale (from AsyncLocalStorage or default) |
 | `getDefaultLocale()`                               | `string` | Get configured default locale                          |
-| `getFallbackLocale()`                              | `string` | Get configured fallback locale                         |
+| `getFallbackLocale()`                              | `string`   | Get first fallback locale (backward compat)            |
+| `getFallbackLocales()`                             | `string[]` | Get the full fallback locale chain                     |
 | `runWithLocale(locale, fn)`                        | `T`      | Execute a function with a specific locale context      |
 | `resolveLocale(requested, available, useFallback)` | `string` | Resolve the best locale to use                         |
 
@@ -480,11 +493,12 @@ export class TranslationListener {
 
 ## Configuration Options
 
-| Option           | Type      | Default         | Description                                                                             |
-| ---------------- | --------- | --------------- | --------------------------------------------------------------------------------------- |
-| `defaultLocale`  | `string`  | `'en'`          | Default locale when none is set                                                         |
-| `fallbackLocale` | `string`  | `defaultLocale` | Locale to fall back to when a translation is missing                                    |
-| `fallbackAny`    | `boolean` | `false`         | If true, fall back to any available locale when both requested and fallback are missing |
+| Option            | Type       | Default            | Description                                                                            |
+| ----------------- | ---------- | ------------------ | -------------------------------------------------------------------------------------- |
+| `defaultLocale`   | `string`   | `'en'`             | Default locale when none is set                                                        |
+| `fallbackLocales` | `string[]` | `[defaultLocale]`  | Ordered list of fallback locales to try when a translation is missing                  |
+| `fallbackLocale`  | `string`   | —                  | Shorthand for a single fallback (sets `fallbackLocales: [value]`). Deprecated.         |
+| `fallbackAny`     | `boolean`  | `false`            | If true, fall back to any available locale when the chain is exhausted                 |
 
 ## Standalone Usage
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ entity.getTranslation('name', 'de'); // 'Bonjour' — skipped 'en', found 'fr'
 
 Resolution order:
 1. The requested locale
-2. Each locale in `fallbackLocales` in order (default: `['en']`)
+2. Each locale in `fallbackLocales` in order (default: `[defaultLocale]`)
 3. Any available locale (if `fallbackAny: true` is configured)
 4. `null` if no translation is found
 
@@ -285,7 +285,7 @@ TranslatableModule.forRootAsync({
   imports: [ConfigModule],
   useFactory: (config: ConfigService) => ({
     defaultLocale: config.get("DEFAULT_LOCALE"),
-    fallbackLocales: config.get("FALLBACK_LOCALES"),
+    fallbackLocales: config.get<string[]>("FALLBACK_LOCALES"),
   }),
   inject: [ConfigService],
 });

--- a/src/interfaces/translatable-options.interface.ts
+++ b/src/interfaces/translatable-options.interface.ts
@@ -1,6 +1,8 @@
 export interface TranslatableModuleOptions {
   defaultLocale?: string;
+  /** @deprecated Use `fallbackLocales` instead. Kept for backward compatibility. */
   fallbackLocale?: string;
+  fallbackLocales?: string[];
   fallbackAny?: boolean;
 }
 

--- a/src/translatable.service.ts
+++ b/src/translatable.service.ts
@@ -18,7 +18,7 @@ export class TranslatableService implements OnModuleInit {
   private readonly localeStorage = new AsyncLocalStorage<string>();
 
   private readonly defaultLocale: string;
-  private readonly fallbackLocale: string;
+  private readonly fallbackLocales: string[];
   private readonly fallbackAny: boolean;
 
   private eventEmitter: any = null;
@@ -29,7 +29,11 @@ export class TranslatableService implements OnModuleInit {
     @Optional() @Inject("EventEmitter2") eventEmitter?: any,
   ) {
     this.defaultLocale = options.defaultLocale ?? "en";
-    this.fallbackLocale = options.fallbackLocale ?? this.defaultLocale;
+    this.fallbackLocales =
+      options.fallbackLocales ??
+      (options.fallbackLocale
+        ? [options.fallbackLocale]
+        : [this.defaultLocale]);
     this.fallbackAny = options.fallbackAny ?? false;
 
     if (eventEmitter) {
@@ -40,7 +44,7 @@ export class TranslatableService implements OnModuleInit {
   onModuleInit(): void {
     TranslatableService.instance = this;
     this.logger.log(
-      `Initialized with defaultLocale="${this.defaultLocale}", fallbackLocale="${this.fallbackLocale}"`,
+      `Initialized with defaultLocale="${this.defaultLocale}", fallbackLocales=[${this.fallbackLocales.map((l) => `"${l}"`).join(", ")}]`,
     );
   }
 
@@ -57,7 +61,11 @@ export class TranslatableService implements OnModuleInit {
   }
 
   getFallbackLocale(): string {
-    return this.fallbackLocale;
+    return this.fallbackLocales[0] ?? this.defaultLocale;
+  }
+
+  getFallbackLocales(): string[] {
+    return [...this.fallbackLocales];
   }
 
   getFallbackAny(): boolean {
@@ -85,8 +93,10 @@ export class TranslatableService implements OnModuleInit {
       return requestedLocale;
     }
 
-    if (translatedLocales.includes(this.fallbackLocale)) {
-      return this.fallbackLocale;
+    for (const fallback of this.fallbackLocales) {
+      if (translatedLocales.includes(fallback)) {
+        return fallback;
+      }
     }
 
     if (this.fallbackAny && translatedLocales.length > 0) {

--- a/src/translatable.service.ts
+++ b/src/translatable.service.ts
@@ -29,11 +29,13 @@ export class TranslatableService implements OnModuleInit {
     @Optional() @Inject("EventEmitter2") eventEmitter?: any,
   ) {
     this.defaultLocale = options.defaultLocale ?? "en";
-    this.fallbackLocales =
+    const fallbackLocales =
       options.fallbackLocales ??
-      (options.fallbackLocale
-        ? [options.fallbackLocale]
-        : [this.defaultLocale]);
+      (options.fallbackLocale ? [options.fallbackLocale] : undefined);
+    this.fallbackLocales =
+      fallbackLocales && fallbackLocales.length > 0
+        ? fallbackLocales
+        : [this.defaultLocale];
     this.fallbackAny = options.fallbackAny ?? false;
 
     if (eventEmitter) {
@@ -61,7 +63,7 @@ export class TranslatableService implements OnModuleInit {
   }
 
   getFallbackLocale(): string {
-    return this.fallbackLocales[0] ?? this.defaultLocale;
+    return this.fallbackLocales[0];
   }
 
   getFallbackLocales(): string[] {

--- a/test/translatable.interceptor.spec.ts
+++ b/test/translatable.interceptor.spec.ts
@@ -150,6 +150,53 @@ describe("TranslatableInterceptor", () => {
       expect(result.name).toBeNull();
     });
 
+    it("should use fallback chain when requested locale is missing", async () => {
+      // Create a separate module with fallbackLocales chain
+      const chainModule = await Test.createTestingModule({
+        providers: [
+          {
+            provide: TRANSLATABLE_OPTIONS,
+            useValue: {
+              defaultLocale: "en",
+              fallbackLocales: ["en", "fr", "ar"],
+            },
+          },
+          TranslatableService,
+          TranslatableInterceptor,
+        ],
+      }).compile();
+
+      const chainService =
+        chainModule.get<TranslatableService>(TranslatableService);
+      const chainInterceptor = chainModule.get<TranslatableInterceptor>(
+        TranslatableInterceptor,
+      );
+      chainService.onModuleInit();
+
+      const entity = new TestProduct();
+      entity.name = { fr: "Bonjour", ar: "مرحبا" };
+      entity.description = { ar: "تحية" };
+      entity.slug = "hello";
+
+      const context = createMockContext("de");
+
+      const result = await new Promise<any>((resolve) => {
+        chainService.runWithLocale("de", () => {
+          firstValueFrom(
+            chainInterceptor.intercept(context, createMockHandler(entity)),
+          ).then(resolve);
+        });
+      });
+
+      // "en" missing, "fr" available for name → "Bonjour"
+      expect(result.name).toBe("Bonjour");
+      // "en" missing, "fr" missing, "ar" available for description → "تحية"
+      expect(result.description).toBe("تحية");
+      expect(result.slug).toBe("hello");
+
+      TranslatableService.resetInstance();
+    });
+
     it("should handle nested entity in plain object wrapper", async () => {
       const entity = new TestProduct();
       entity.name = { en: "Hello", ar: "مرحبا" };

--- a/test/translatable.mixin.spec.ts
+++ b/test/translatable.mixin.spec.ts
@@ -163,6 +163,48 @@ describe("TranslatableMixin", () => {
       entity.setTranslation("name", "fr", "Bonjour");
       expect(entity.getTranslation("name", "en")).toBeNull();
     });
+
+    it("should try fallback chain in order", async () => {
+      await setupService({ fallbackLocales: ["en", "fr", "ar"] });
+
+      entity.setTranslation("name", "fr", "Bonjour");
+      entity.setTranslation("name", "ar", "مرحبا");
+
+      // "en" missing, "fr" available → returns "fr"
+      expect(entity.getTranslation("name", "de")).toBe("Bonjour");
+    });
+
+    it("should skip missing chain locales and use next available", async () => {
+      await setupService({ fallbackLocales: ["en", "fr", "ar"] });
+
+      entity.setTranslation("name", "ar", "مرحبا");
+
+      // "en" missing, "fr" missing, "ar" available → returns "ar"
+      expect(entity.getTranslation("name", "de")).toBe("مرحبا");
+    });
+
+    it("should exhaust chain before using fallbackAny", async () => {
+      await setupService({
+        fallbackLocales: ["en", "fr"],
+        fallbackAny: true,
+      });
+
+      entity.setTranslation("name", "ja", "こんにちは");
+
+      // chain exhausted, fallbackAny picks first available
+      expect(entity.getTranslation("name", "de")).toBe("こんにちは");
+    });
+
+    it("should return null when chain exhausted and fallbackAny is false", async () => {
+      await setupService({
+        fallbackLocales: ["en", "fr"],
+        fallbackAny: false,
+      });
+
+      entity.setTranslation("name", "ja", "こんにちは");
+
+      expect(entity.getTranslation("name", "de")).toBeNull();
+    });
   });
 
   describe("current locale", () => {

--- a/test/translatable.service.spec.ts
+++ b/test/translatable.service.spec.ts
@@ -52,6 +52,7 @@ describe("TranslatableService", () => {
 
       expect(service.getDefaultLocale()).toBe("ar");
       expect(service.getFallbackLocale()).toBe("fr");
+      expect(service.getFallbackLocales()).toEqual(["fr"]);
       expect(service.getFallbackAny()).toBe(true);
     });
 
@@ -59,6 +60,36 @@ describe("TranslatableService", () => {
       service = await createService({ defaultLocale: "fr" });
 
       expect(service.getFallbackLocale()).toBe("fr");
+      expect(service.getFallbackLocales()).toEqual(["fr"]);
+    });
+
+    it("should accept fallbackLocales array", async () => {
+      service = await createService({
+        fallbackLocales: ["en", "fr", "ar"],
+      });
+
+      expect(service.getFallbackLocales()).toEqual(["en", "fr", "ar"]);
+      expect(service.getFallbackLocale()).toBe("en");
+    });
+
+    it("should prefer fallbackLocales over fallbackLocale", async () => {
+      service = await createService({
+        fallbackLocale: "de",
+        fallbackLocales: ["en", "fr"],
+      });
+
+      expect(service.getFallbackLocales()).toEqual(["en", "fr"]);
+      expect(service.getFallbackLocale()).toBe("en");
+    });
+
+    it("should fall back to defaultLocale when fallbackLocales is empty", async () => {
+      service = await createService({
+        defaultLocale: "ar",
+        fallbackLocales: [],
+      });
+
+      expect(service.getFallbackLocales()).toEqual([]);
+      expect(service.getFallbackLocale()).toBe("ar");
     });
 
     it("should set static instance on module init", async () => {
@@ -155,6 +186,47 @@ describe("TranslatableService", () => {
 
       const result = service.resolveLocale("fr", [], true);
       expect(result).toBe("fr");
+    });
+
+    it("should try fallback chain in order", async () => {
+      service = await createService({
+        fallbackLocales: ["en", "fr", "ar"],
+      });
+
+      // "en" missing, "fr" available → returns "fr"
+      const result = service.resolveLocale("de", ["fr", "ar"], true);
+      expect(result).toBe("fr");
+    });
+
+    it("should try second fallback when first is also missing", async () => {
+      service = await createService({
+        fallbackLocales: ["en", "fr", "ar"],
+      });
+
+      // "en" missing, "fr" missing, "ar" available → returns "ar"
+      const result = service.resolveLocale("de", ["ar", "ja"], true);
+      expect(result).toBe("ar");
+    });
+
+    it("should fall through entire chain before using fallbackAny", async () => {
+      service = await createService({
+        fallbackLocales: ["en", "fr"],
+        fallbackAny: true,
+      });
+
+      // chain exhausted, fallbackAny picks first available
+      const result = service.resolveLocale("de", ["ja", "ko"], true);
+      expect(result).toBe("ja");
+    });
+
+    it("should return requested locale when chain is exhausted and fallbackAny is false", async () => {
+      service = await createService({
+        fallbackLocales: ["en", "fr"],
+        fallbackAny: false,
+      });
+
+      const result = service.resolveLocale("de", ["ja", "ko"], true);
+      expect(result).toBe("de");
     });
   });
 

--- a/test/translatable.service.spec.ts
+++ b/test/translatable.service.spec.ts
@@ -82,13 +82,13 @@ describe("TranslatableService", () => {
       expect(service.getFallbackLocale()).toBe("en");
     });
 
-    it("should fall back to defaultLocale when fallbackLocales is empty", async () => {
+    it("should normalize empty fallbackLocales to [defaultLocale]", async () => {
       service = await createService({
         defaultLocale: "ar",
         fallbackLocales: [],
       });
 
-      expect(service.getFallbackLocales()).toEqual([]);
+      expect(service.getFallbackLocales()).toEqual(["ar"]);
       expect(service.getFallbackLocale()).toBe("ar");
     });
 


### PR DESCRIPTION
## Summary

- Add `fallbackLocales: string[]` option — an ordered list of fallback locales to try when the requested locale is missing
- `resolveLocale()` iterates the chain in order before falling back to `fallbackAny`
- Add `getFallbackLocales()` getter to `TranslatableService`
- Keep `fallbackLocale` as backward-compatible shorthand (deprecated)
- 180 tests at 100% coverage

### Example

```typescript
TranslatableModule.forRoot({
  fallbackLocales: ['en', 'fr', 'ar'],
})

// Request 'de', entity has { fr: 'Bonjour', ar: 'مرحبا' }
entity.getTranslation('name', 'de'); // 'Bonjour' — skipped 'en', found 'fr'
```

## Test plan

- [x] Chain resolves in order (skips missing, picks first available)
- [x] Falls through entire chain before `fallbackAny`
- [x] Returns null when chain exhausted and `fallbackAny` is false
- [x] `fallbackLocales` takes priority over deprecated `fallbackLocale`
- [x] Empty chain falls back to `defaultLocale`
- [x] Backward compat: existing `fallbackLocale` configs still work
- [x] Interceptor resolves different fields to different chain positions
- [x] Mixin resolves with chain
- [x] 100% coverage maintained

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)